### PR TITLE
docs(readme): demote iOS tier to screenshot+vision, mark tvOS unverified (credit @m13v, #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 Up to 34+ MCP tools (27 core + optional audio, camera, spaces). Background interaction via the macOS Accessibility API. 379us per element access. Audio capture, camera input, virtual desktop isolation. Your AI agent connects and your Mac becomes an extension of it.
 
+**Platform scope.** AX-first-with-vision-fallback is **macOS-only**. iOS/iPadOS support is tracked in [#43](https://github.com/MikkoParkkola/axterminator/issues/43) as a future capability and, when shipped, will be **screenshot + vision only** — the `idevice`/RPPairing surface does not expose AX trees for third-party apps, and UIAutomation would require an on-device test runner (breaks the "mac-only agent, no on-device prereqs" contract). Reported screenshot latency via CoreDeviceProxy: **~350ms USB, ~700ms WiFi** (credit [@m13v](https://github.com/MikkoParkkola/axterminator/issues/43#issuecomment-4274488358)). tvOS is **unverified** — the RSD surface is narrower than `idevice`'s tvOS target suggests; please open an issue with device evidence if you've tested. See [#42](https://github.com/MikkoParkkola/axterminator/issues/42) for the AX-first-vs-vision-first positioning rationale.
+
 ## Deploy
 
 **Tell your AI assistant** (recommended):
@@ -164,6 +166,15 @@ AXTerminator uses an undocumented behavior of Apple's Accessibility API: `AXUIEl
 | Drag, system dialogs | No | Require cursor control / always grab focus |
 | Gesture recognition | Yes | Verified: thumbs_up at 88.8% confidence |
 | Speech transcription | Yes | Verified: on-device, requires Dictation enabled |
+
+**Platform coverage** (see [#43](https://github.com/MikkoParkkola/axterminator/issues/43)):
+
+| Platform | AX tree | Screenshot | App launch | Status |
+|----------|:-------:|:----------:|:----------:|--------|
+| macOS 12+ | ✅ | ✅ | ✅ | Shipped; sub-ms AX path |
+| iOS / iPadOS | ❌ (third-party apps) | ✅ (~350ms USB / ~700ms WiFi) | ✅ | **Planned, screenshot + vision only** — no AX semantics |
+| tvOS | ❔ | ❔ | ❔ | **Unverified** — RSD surface narrower than `idevice` suggests |
+| visionOS / watchOS | ❌ | ❌ | ❌ | Out of scope |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Corrects the README's platform-scope framing per @m13v's feedback in [#43](https://github.com/MikkoParkkola/axterminator/issues/43). The prior DoR notes implied "iOS + iPadOS + tvOS" semantic parity; @m13v's reality check made clear that:

- `idevice`/RPPairing exposes screenshots, app launch, syslog, afc — but **no AX tree for third-party iOS apps**.
- UIAutomation needs an on-device test runner with code signing, which would break the "mac-only agent, no on-device prereqs" contract.
- Screenshot latency via CoreDeviceProxy is **~350ms USB / ~700ms WiFi** — a different product from the sub-ms macOS AX path.
- tvOS's RSD surface is narrower than `idevice`'s tvOS target suggests.

## Changes

- `README.md` (top of the feature overview): added a **Platform scope** paragraph stating AX-first-with-vision-fallback is macOS-only, that iOS/iPadOS (when shipped) will be screenshot + vision only, and citing the latency numbers.
- `README.md` (Known Limitations): added a **Platform coverage** matrix — macOS ✅, iOS/iPadOS planned/screenshot-only, tvOS unverified, visionOS/watchOS out of scope.
- Cross-links [#42](https://github.com/MikkoParkkola/axterminator/issues/42) (positioning rationale) and [#43](https://github.com/MikkoParkkola/axterminator/issues/43) (iOS spike).
- Credits @m13v's specific comment: https://github.com/MikkoParkkola/axterminator/issues/43#issuecomment-4274488358

No code changes, no API changes. Documentation only.

## Credit

Thanks to [@m13v](https://github.com/m13v) for the expert review that caught this before any iOS claims shipped. Latency data is theirs; I've cited it inline.

## Test plan

- [ ] README renders on GitHub without broken tables
- [ ] Both issue links (#42, #43) resolve
- [ ] @m13v comment link resolves to the correct comment
- [ ] Latency claims (~350ms USB / ~700ms WiFi) attributed to source
- [ ] No lingering "iOS + iPadOS + tvOS" semantic-parity language elsewhere in docs

## Related

- Closes README action items (1), (2), (3) from https://github.com/MikkoParkkola/axterminator/issues/43#issuecomment (owner reply to @m13v)
- Does not resolve #43 itself — the iOS spike (`ax_ios_list_devices` / `ax_ios_screenshot`) is still pending hardware time.
