### PR TITLE
fix: harden MCP lifecycle and temp file handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,16 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
       - run: cargo clippy --all-features -- -D warnings -A unexpected_cfgs
+
+  bench-build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+      # Type-check benchmarks in CI so performance-critical paths keep building.
+      # Full Criterion runs still belong on an interactive macOS host because
+      # Accessibility and WindowServer availability vary on hosted runners.
+      # All-features coverage is handled by the check/test/clippy jobs; keeping
+      # this as `cargo check` avoids release/LTO link cost on every PR.
+      - run: cargo check --benches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,73 @@
 
 MCP server + CLI that gives AI agents the ability to see and control macOS applications via the Accessibility API. 27 core tools, up to 34+ with feature flags. Rust, macOS-only.
 
+> `AGENTS.md` in this repo is the public install-facing guide for end-user agents (see `trvl` pattern). This file (`CLAUDE.md`) is for contributing agents. They are intentionally diverged; do not symlink.
+
+## Product Vision
+
+AXTerminator lets an AI agent observe and operate macOS applications **in the background**, with sub-millisecond element access (~379 us), self-healing locators, and structured-output MCP tools. It is the eyes-and-hands of a macOS agent: click, type, query UI state, capture screens, record audio, see camera input, manage virtual desktops. AX-first with vision-fallback means most interactions use the accessibility tree (fast, reliable, semantic), falling back to screenshot+vision only when AX is not available (e.g. Electron web views without proper ARIA).
+
+The boundary is macOS-only. iOS/iPadOS support is tracked but will be screenshot+vision only — the `idevice`/RPPairing surface does not expose AX trees for third-party apps, and UIAutomation would require an on-device test runner which breaks the "mac-only agent, no on-device prereqs" contract.
+
+## Current Status
+
+- **v0.9.1** · Rust stable · macOS 12+ · MIT + Apache-2.0 dual license
+- **27 core tools** (default features) plus up to 34+ with `audio`, `camera`, `spaces`, `watch`, `context`, `docker`, `parakeet`, `http-transport` feature flags
+- **~1000 tests** on default features; full suite with `--all-features`; CI runs `test --all-features` on macOS
+- **Performance**: 379 us per element access, 7-strategy self-healing locators, ObjC FFI for CoreFoundation / CoreGraphics / AVFoundation
+- **iOS**: tracked in #43, demoted to screenshot+vision tier (~350 ms USB, ~700 ms WiFi via CoreDeviceProxy)
+- **tvOS**: unverified; RSD surface narrower than `idevice`'s tvOS target suggests
+
+## Plan Forward (near-term, technical)
+
+- **Release cadence**: v0.9.1 unblocked for aarch64-apple-darwin (#50); continue clippy-1.95 drift cleanup
+- **iOS screenshot-vision path**: #43 — implement when "mac-only agent, no on-device prereqs" can be preserved
+- **Dependabot cadence**: frequent automated PRs; rebase-and-ship once CI is green
+- **Companion bundles**: axterminator auto-loads alongside mcp-gateway + nab + hebb in botnaut-client
+
+## Decisions Locked (do not re-litigate)
+
+| Decision | Rationale | Do not |
+|---|---|---|
+| **macOS-only for AX-first path** | AX API is the entire performance + reliability story | Introduce Linux/Windows AX support that is not a thin shim |
+| **AX-first with vision fallback** (not vision-first) | AX is faster, more reliable, semantic; vision is the escape hatch | Make vision the default pipeline |
+| **Background interaction** (no mouse-takeover required) | Parallel agent work; user keeps using their machine | Require focus-stealing; avoid mouse-driven automation |
+| **Accessibility permissions required for terminal/host** | macOS security model; no workaround | Add code paths that work around Privacy & Security panel |
+| **No on-device prereqs for iOS path** | Keeps "mac-only agent" contract intact | Require iOS UIAutomation test runner install |
+| **Session state via `OnceLock<Mutex>` singleton** (`McpSession`) | Shared state across tool handlers; tests take `session_test_lock()` | Add parallel singletons; avoid per-tool mutable globals |
+| **Feature flags for optional modules** (audio / camera / spaces / watch / context / docker / parakeet / http-transport) | Keep default build lean; opt-in heavy deps | Promote feature-gated modules to default without explicit trade-off |
+| **No unsafe without `// SAFETY:`** | Discipline for ObjC FFI + CF bridging | Add unsafe blocks without the comment |
+| **License: MIT + Apache-2.0 dual** | Standard Rust ecosystem defaults | Relicense without explicit user direction |
+
+## Anti-Patterns (things agents get wrong in this repo)
+
+- **Implementing iOS via `idevice` UIAutomation** — breaks "mac-only agent, no on-device prereqs" contract. Screenshot+vision only per #43.
+- **Making vision the default path** — AX-first is the performance moat; vision is fallback, not equivalent.
+- **Forgetting `destructiveHint` on automation tools** — axterminator literally drives the user's machine. See MIK-2986: err toward `destructiveHint=true` when uncertain. Any tool that types, clicks, modifies system state must carry it.
+- **Sharing `McpSession` across tests without the test lock** — tests break intermittently. Acquire `session_test_lock()` from `tools_capture`.
+- **Adding ObjC FFI without updating `build.rs`** — camera/audio `.m` files only compile when the matching feature is enabled; the build script gates this.
+- **Skipping `live_` test naming convention** — CI skips these explicitly; tests that hit real macOS APIs must use the prefix.
+
+## Guidance for Agents
+
+- **Before editing a tool schema**: check MCP 2025-11-25 annotation matrix in MIK-2986; every tool needs `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` plus `title`.
+- **When adding a feature-gated module**: mirror `src/audio/` pattern — feature flag in `Cargo.toml`, `cfg`-gated module, `.m` file compilation in `build.rs`, integration test behind `live_` prefix.
+- **Cross-app interaction**: use `src/app.rs` for app connection and `src/element.rs` for element abstraction — do not bypass to raw `accessibility.rs` FFI.
+- **Self-healing locators**: the 7-strategy system in `src/healing.rs` / `healing_match.rs` is the primary stability mechanism; do not bypass it with hard-coded selectors.
+- **Build + test parity with CI**: `cargo fmt --check && cargo clippy --all-features -- -D warnings -A unexpected_cfgs && cargo test --all-features -- --skip live_`
+
+## Where to Look
+
+| You want to… | Read |
+|---|---|
+| Onboard a human user / end-user agent | `AGENTS.md` (public install-facing) + `README.md` |
+| MCP tool definitions | `src/mcp/tools_*.rs` |
+| Accessibility FFI | `src/accessibility.rs` + `src/element.rs` |
+| Self-healing locators | `src/healing.rs` + `src/healing_match.rs` |
+| Scene graph / UI patterns | `src/intent.rs` + `src/intent_matching.rs` |
+| Benchmarks | `benches/` |
+| Known limitations | README §Known Limitations + #43 (iOS) + #42 (AX-first rationale) |
+
 ## Build & Test
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,15 +1105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,29 +1384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,15 +1584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,12 +1663,6 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -2010,7 +1963,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ cli = ["dep:clap", "dep:clap_complete"]
 spaces = []
 # http-transport: Streamable HTTP + SSE transport (axum, tokio-stream).
 # Feature-gated to keep the default CLI binary lean.
-http-transport = ["dep:axum", "dep:tokio-stream", "dep:rand"]
+http-transport = ["dep:axum", "dep:tokio-stream"]
 # audio: on-device audio capture, speech recognition, and TTS via CoreAudio /
 # Speech.framework / AVFoundation.  Off by default to avoid triggering macOS
 # TCC permission dialogs for users who do not need audio capabilities.
@@ -89,10 +89,12 @@ clap_complete = { version = "4.5", optional = true }
 # manual installation required.  Zero impact on binary size when disabled.
 ort = { version = "2.0.0-rc.12", optional = true, features = ["download-binaries"] }
 
+# Random token/password generation
+rand = "0.10"
+
 # HTTP transport (feature-gated)
 axum = { version = "0.8", features = ["http1", "http2", "json", "tokio"], optional = true }
 tokio-stream = { version = "0.1", features = ["sync"], optional = true }
-rand = { version = "0.10", optional = true }
 
 # Base64 encoding for screenshot data
 base64 = "0.22"
@@ -109,7 +111,7 @@ cocoa = "0.26"
 block = "0.1"
 
 # Async runtime
-tokio = { version = "1.44", features = ["full"] }
+tokio = { version = "1.44", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 # CancellationToken for cooperative task shutdown (watch feature)
 tokio-util = { version = "0.7", features = ["rt"], optional = true }
 
@@ -137,6 +139,9 @@ sysinfo = "0.38"
 # URL parsing
 url = "2.5"
 
+# Temporary files for screenshot capture paths passed to macOS `screencapture`.
+tempfile = "3.15"
+
 # Hashing for tree comparison
 ahash = "0.8"
 
@@ -146,7 +151,6 @@ once_cell = "1.20"
 
 [dev-dependencies]
 criterion = "0.8"
-tempfile = "3.15"
 
 [build-dependencies]
 # cc is used by build.rs to compile camera_objc.m when the `camera` feature is enabled.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,6 +1,6 @@
 # AXTerminator Design Document
 
-**Status**: Implemented | **Version**: 0.6.1 | **Last Updated**: 2026-03-21
+**Status**: Implemented | **Version**: 0.9.1 | **Last Updated**: 2026-04-26
 
 ## Overview
 
@@ -35,10 +35,10 @@ Action overhead:       20 us    (Criterion, perform_action_overhead)
 +-----------------------------------------------------------------+
 |                                                                 |
 |  +-----------------------------------------------------------+ |
-|  |                    Python API (PyO3)                       | |
-|  |  import axterminator as ax                                 | |
-|  |  app = ax.app("Safari")                                    | |
-|  |  app.find("Save").click()  # Background by default         | |
+|  |                    CLI + MCP Interfaces                    | |
+|  |  axterminator find Safari "Save"                           | |
+|  |  axterminator click Safari "Save"                          | |
+|  |  axterminator mcp serve                                    | |
 |  +-----------------------------------------------------------+ |
 |                              |                                  |
 |                              v                                  |

--- a/docs/design/MCP_SERVER_DESIGN.md
+++ b/docs/design/MCP_SERVER_DESIGN.md
@@ -1,8 +1,8 @@
 # AXTerminator MCP Server Design Document
 
-**Status**: Draft | **Version**: 3.0 | **Date**: 2026-03-19
-**Protocol**: MCP 2025-11-25 | **SDK**: `rmcp` 1.2.0 (official Rust MCP SDK)
-**Runtime**: Pure Rust (unified `axterminator` binary) | **Deprecates**: `server.py` (Python)
+**Status**: Implemented | **Version**: 3.1 | **Date**: 2026-04-26
+**Protocol**: MCP 2025-11-05 | **SDK**: Hand-rolled Rust protocol layer
+**Runtime**: Pure Rust (unified `axterminator` binary) | **Python API**: Historical design, not shipped in the current crate
 **Author**: Mikko Parkkola
 
 ---
@@ -35,8 +35,9 @@ macOS.
    push UI state changes to agents. Agents react to events rather than polling.
 6. **Composable operations**: Complex multi-step workflows compose from atomic tools
    with transaction semantics, rollback on failure, and macro recording/replay.
-7. **Pure Rust, three interfaces**: One Rust core exposes CLI, MCP server, and Python
-   API. No Python in the hot path.
+7. **Pure Rust, two shipped interfaces**: One Rust core exposes CLI and MCP server
+   entry points. Historical Python/PyO3 design notes remain in this document for
+   context, but the current crate ships a Rust library plus CLI/MCP binary.
 
 ### What This Enables
 
@@ -63,12 +64,12 @@ macOS.
               +---------------------+---------------------+
               |                     |                     |
     +---------+---------+ +--------+--------+ +----------+---------+
-    | CLI (clap)        | | MCP Server      | | Python API (pyo3)  |
-    | axterminator find | | axterminator    | | import axterminator|
-    | axterminator click| |   mcp serve     | | ax.app("Safari")   |
+    | CLI (clap)        | | MCP Server      | | Rust Library       |
+    | axterminator find | | axterminator    | | axterminator::     |
+    | axterminator click| |   mcp serve     | |   app::AXApp       |
     +---------+---------+ +--------+--------+ +----------+---------+
               |                     |                     |
-        Human / shell          AI agents            Python scripts
+        Human / shell          AI agents            Rust consumers
 ```
 
 The `axterminator` binary is the single entry point:
@@ -3114,7 +3115,9 @@ For remote HTTP:
 
 ## Appendix A: MCP Protocol Capability Matrix
 
-Complete mapping of every MCP 2025-11-25 capability to our implementation decision.
+Complete mapping of implemented MCP 2025-11-05 behavior. Tool/resource
+annotations additionally follow the semantic hint fields documented in the
+2025-11-25 draft.
 
 | MCP Capability | Use? | Phase | Notes |
 |----------------|:----:|:-----:|-------|
@@ -3152,9 +3155,11 @@ Complete mapping of every MCP 2025-11-25 capability to our implementation decisi
 | **Session management** | YES | 4 | MCP-Session-Id for HTTP transport |
 | **Resumability** | YES | 4 | SSE event IDs, Last-Event-ID reconnection |
 
-## Appendix B: Rust MCP SDK Landscape (as of 2026-03-19)
+## Appendix B: Rust MCP SDK Landscape (historical, as of 2026-03-19)
 
-Research summary of all Rust MCP crates evaluated. See Section 2A for the selection rationale.
+Research summary of Rust MCP crates evaluated during the original design phase.
+The current implementation uses a hand-rolled Rust protocol layer instead of an
+SDK dependency.
 
 | Crate | Version | Downloads | Repository | Notes |
 |-------|---------|-----------|------------|-------|
@@ -3167,8 +3172,9 @@ Research summary of all Rust MCP crates evaluated. See Section 2A for the select
 | `mcp-kit` | 0.4.0 | 118 | github.com/KSD-CO/mcp-kit | Plugin system. Too early. |
 | `mcp-gateway` | 2.7.3 | 105 | github.com/MikkoParkkola/mcp-gateway | Meta-MCP multiplexer (our own). |
 
-**Decision**: `rmcp` 1.2.0 is the only viable choice. Official, 5.7M downloads,
-full protocol, used by our Windows counterpart (mediar-ai/terminator).
+**Current implementation note**: this SDK survey is retained as historical
+context. The shipped crate uses local protocol structs and transport handlers so
+the MCP layer remains dependency-light and tightly controlled.
 
 ## Appendix C: Wire Protocol Examples
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -224,10 +224,18 @@ impl AXApp {
     /// primary method fails.
     fn capture_screenshot(&self) -> AXResult<Vec<u8>> {
         let wid = self.cg_window_id()?;
-        let temp_path = format!("/tmp/axterminator_screenshot_{}.png", self.pid);
+        let temp_dir = tempfile::Builder::new()
+            .prefix("axterminator_screenshot_")
+            .tempdir()
+            .map_err(|e| AXError::SystemError(e.to_string()))?;
+        let temp_path = temp_dir.path().join("capture.png");
 
         let output = Command::new("screencapture")
-            .args(["-l", &wid.to_string(), "-o", "-x", &temp_path])
+            .arg("-l")
+            .arg(wid.to_string())
+            .arg("-o")
+            .arg("-x")
+            .arg(&temp_path)
             .output()
             .map_err(|e| AXError::SystemError(e.to_string()))?;
 
@@ -236,7 +244,6 @@ impl AXApp {
         }
 
         let data = std::fs::read(&temp_path).map_err(|e| AXError::SystemError(e.to_string()))?;
-        let _ = std::fs::remove_file(&temp_path);
         Ok(data)
     }
 
@@ -354,10 +361,17 @@ impl AXApp {
             .bounds()
             .ok_or_else(|| AXError::SystemError("Window has no bounds".into()))?;
 
-        let temp_path = format!("/tmp/axterminator_screenshot_{}.png", self.pid);
+        let temp_dir = tempfile::Builder::new()
+            .prefix("axterminator_screenshot_")
+            .tempdir()
+            .map_err(|e| AXError::SystemError(e.to_string()))?;
+        let temp_path = temp_dir.path().join("capture.png");
         let region = format!("{},{},{},{}", x as i32, y as i32, w as i32, h as i32);
         let output = Command::new("screencapture")
-            .args(["-R", &region, "-x", &temp_path])
+            .arg("-R")
+            .arg(&region)
+            .arg("-x")
+            .arg(&temp_path)
             .output()
             .map_err(|e| AXError::SystemError(e.to_string()))?;
 
@@ -368,7 +382,6 @@ impl AXApp {
         }
 
         let data = std::fs::read(&temp_path).map_err(|e| AXError::SystemError(e.to_string()))?;
-        let _ = std::fs::remove_file(&temp_path);
         Ok(data)
     }
 

--- a/src/audio/speech.rs
+++ b/src/audio/speech.rs
@@ -359,8 +359,8 @@ fn request_speech_authorization() -> Result<(), AudioError> {
 /// Perform on-device transcription via `SFSpeechRecognizer`.
 ///
 /// Ensures speech recognition permission is obtained before attempting
-/// transcription.  Writes a temporary WAV file in `/tmp`, runs the
-/// recognizer, then deletes it.
+/// transcription. Writes a private temporary WAV file, runs the recognizer,
+/// then lets the temp file clean itself up.
 fn transcribe_with_sf_speech(audio: &AudioData, locale: &str) -> Result<String, AudioError> {
     // Ensure authorization is present — this is the fix for BUG #26.
     // When status is NotDetermined the system dialog is shown and we block
@@ -370,42 +370,24 @@ fn transcribe_with_sf_speech(audio: &AudioData, locale: &str) -> Result<String, 
 
     let wav_bytes = audio.to_wav_bytes();
 
-    let tmp_path = write_temp_wav(&wav_bytes)
+    let tmp_file = write_temp_wav(&wav_bytes)
         .map_err(|e| AudioError::Framework(format!("Temp file write failed: {e}")))?;
+    let tmp_path = tmp_file.path().to_string_lossy().into_owned();
 
-    let result = run_sf_speech_recognizer(&tmp_path, locale);
-
-    // Always delete the temp file, even on error.
-    let _ = std::fs::remove_file(&tmp_path);
-
-    result
+    run_sf_speech_recognizer(&tmp_path, locale)
 }
 
-/// Write `bytes` to a `0600`-permissioned temp file under `/tmp`.
-///
-/// Each call produces a unique path by combining the process ID with the
-/// current time in nanoseconds, making concurrent calls safe within the
-/// same process.
-fn write_temp_wav(bytes: &[u8]) -> Result<String, std::io::Error> {
-    use std::os::unix::fs::OpenOptionsExt;
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.subsec_nanos())
-        .unwrap_or(0);
-    let path = format!(
-        "/tmp/axterminator_audio_{}_{}.wav",
-        std::process::id(),
-        nanos
-    );
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&path)?;
-    std::io::Write::write_all(&mut file, bytes)?;
-    Ok(path)
+/// Write `bytes` to a unique `0600`-permissioned temp WAV file.
+fn write_temp_wav(bytes: &[u8]) -> Result<tempfile::NamedTempFile, std::io::Error> {
+    use std::io::Write as _;
+
+    let mut file = tempfile::Builder::new()
+        .prefix("axterminator_audio_")
+        .suffix(".wav")
+        .tempfile()?;
+    file.write_all(bytes)?;
+    file.flush()?;
+    Ok(file)
 }
 
 /// Run `SFSpeechRecognizer` on a WAV file at `path`.
@@ -839,8 +821,8 @@ mod tests {
     fn write_temp_wav_creates_readable_file() {
         use std::os::unix::fs::PermissionsExt;
         let bytes = encode_wav_pcm16(&[], SAMPLE_RATE, CHANNELS);
-        let path = write_temp_wav(&bytes).unwrap();
-        let meta = std::fs::metadata(&path).unwrap();
+        let file = write_temp_wav(&bytes).unwrap();
+        let meta = std::fs::metadata(file.path()).unwrap();
         let mode = meta.permissions().mode();
         // File must be owner-only (0600)
         assert_eq!(
@@ -849,7 +831,6 @@ mod tests {
             "expected mode 0600, got {:o}",
             mode & 0o777
         );
-        let _ = std::fs::remove_file(&path);
     }
 
     #[test]
@@ -857,22 +838,21 @@ mod tests {
         // GIVEN: 16 silence samples
         let samples: Vec<f32> = vec![0.0; 16];
         let bytes = encode_wav_pcm16(&samples, SAMPLE_RATE, CHANNELS);
-        let path = write_temp_wav(&bytes).unwrap();
-        let content = std::fs::read(&path).unwrap();
+        let file = write_temp_wav(&bytes).unwrap();
+        let content = std::fs::read(file.path()).unwrap();
         // THEN: file starts with RIFF magic
         assert_eq!(&content[0..4], b"RIFF");
-        let _ = std::fs::remove_file(&path);
     }
 
     #[test]
     fn write_temp_wav_paths_are_unique_across_calls() {
         // GIVEN: two rapid successive calls
         let bytes = encode_wav_pcm16(&[], SAMPLE_RATE, CHANNELS);
-        let p1 = write_temp_wav(&bytes).unwrap();
-        let p2 = write_temp_wav(&bytes).unwrap();
+        let f1 = write_temp_wav(&bytes).unwrap();
+        let f2 = write_temp_wav(&bytes).unwrap();
+        let p1 = f1.path().to_path_buf();
+        let p2 = f2.path().to_path_buf();
         // THEN: different paths (no clobbering)
         assert_ne!(p1, p2);
-        let _ = std::fs::remove_file(&p1);
-        let _ = std::fs::remove_file(&p2);
     }
 }

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -679,10 +679,17 @@ fn capture_primary_display_png() -> Result<(String, u32, u32, Vec<u8>), String> 
     let width = bounds.size.width as u32;
     let height = bounds.size.height as u32;
 
-    // Capture to a temp file; -x suppresses the shutter sound.
-    let tmp = format!("/tmp/axterminator_capture_{}.png", std::process::id());
+    // Capture to a private temp directory; -x suppresses the shutter sound.
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("axterminator_capture_")
+        .tempdir()
+        .map_err(|e| format!("failed to create capture temp directory: {e}"))?;
+    let tmp = tmp_dir.path().join("capture.png");
     let output = Command::new("screencapture")
-        .args(["-x", "-D", "1", &tmp])
+        .arg("-x")
+        .arg("-D")
+        .arg("1")
+        .arg(&tmp)
         .output()
         .map_err(|e| format!("screencapture failed to launch: {e}"))?;
 
@@ -694,7 +701,6 @@ fn capture_primary_display_png() -> Result<(String, u32, u32, Vec<u8>), String> 
     }
 
     let png_bytes = std::fs::read(&tmp).map_err(|e| format!("failed to read capture file: {e}"))?;
-    let _ = std::fs::remove_file(&tmp);
 
     let png_base64 = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
     Ok((png_base64, width, height, png_bytes))

--- a/src/docker_browser.rs
+++ b/src/docker_browser.rs
@@ -120,7 +120,7 @@ pub struct NekoConfig {
     pub cdp_port: u16,
     /// Host port mapped to the container's VNC endpoint.
     pub vnc_port: u16,
-    /// Optional Neko admin password (defaults to `"admin"`).
+    /// Optional Neko admin password.
     pub admin_password: String,
     /// Container name prefix (defaults to `"neko"`).
     pub name_prefix: String,
@@ -166,7 +166,7 @@ impl NekoConfig {
             height: 1080,
             cdp_port: base_cdp,
             vnc_port: base_vnc,
-            admin_password: "admin".into(),
+            admin_password: generated_admin_password(),
             name_prefix: "neko".into(),
         }
     }
@@ -688,9 +688,9 @@ fn build_docker_args(config: &NekoConfig, name: &str) -> Vec<String> {
         "--label".into(),
         "axterminator.neko=1".into(),
         "--publish".into(),
-        format!("{}:9222", config.cdp_port),
+        format!("127.0.0.1:{}:9222", config.cdp_port),
         "--publish".into(),
-        format!("{}:5900", config.vnc_port),
+        format!("127.0.0.1:{}:5900", config.vnc_port),
         "--shm-size".into(),
         "2g".into(),
         "--env".into(),
@@ -701,6 +701,27 @@ fn build_docker_args(config: &NekoConfig, name: &str) -> Vec<String> {
         "NEKO_REMOTE_DEBUGGING_PORT=9222".into(),
         config.browser.docker_image(),
     ]
+}
+
+/// Generate a random default Neko admin password.
+///
+/// Docker browser endpoints are bound to loopback, but a non-fixed password
+/// still avoids the footgun of a well-known credential if users override port
+/// publishing or attach their own container network.
+fn generated_admin_password() -> String {
+    use rand::Rng as _;
+
+    let mut bytes = [0u8; 24];
+    rand::rng().fill_bytes(&mut bytes);
+    format!("axt-{}", encode_hex(&bytes))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::new(), |mut s, b| {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -828,7 +849,9 @@ mod tests {
         assert_eq!(cfg.height, 1080);
         assert_eq!(cfg.cdp_port, 9222);
         assert_eq!(cfg.vnc_port, 5900);
-        assert_eq!(cfg.admin_password, "admin");
+        assert!(cfg.admin_password.starts_with("axt-"));
+        assert_eq!(cfg.admin_password.len(), 52);
+        assert_ne!(cfg.admin_password, "admin");
         assert_eq!(cfg.name_prefix, "neko");
     }
 
@@ -1013,8 +1036,8 @@ mod tests {
         assert!(args.contains(&"2g".into()));
         assert!(args.contains(&"--label".into()));
         assert!(args.contains(&"axterminator.neko=1".into()));
-        assert!(args.iter().any(|a| a.contains("9222:9222")));
-        assert!(args.iter().any(|a| a.contains("5900:5900")));
+        assert!(args.iter().any(|a| a == "127.0.0.1:9222:9222"));
+        assert!(args.iter().any(|a| a == "127.0.0.1:5900:5900"));
         assert!(args
             .iter()
             .any(|a| a.contains("ghcr.io/m1k1o/neko/chromium")));
@@ -1032,8 +1055,8 @@ mod tests {
         // WHEN
         let args = build_docker_args(&cfg, "neko-firefox-9500");
         // THEN
-        assert!(args.iter().any(|a| a.contains("9500:9222")));
-        assert!(args.iter().any(|a| a.contains("5950:5900")));
+        assert!(args.iter().any(|a| a == "127.0.0.1:9500:9222"));
+        assert!(args.iter().any(|a| a == "127.0.0.1:5950:5900"));
         assert!(args.iter().any(|a| a.contains("1280x720")));
         assert!(args
             .iter()

--- a/src/element.rs
+++ b/src/element.rs
@@ -358,21 +358,21 @@ impl AXElement {
 
         // Use CGWindowListCreateImage to capture the region
         // For simplicity, use screencapture command with region
-        let temp_path = format!(
-            "/tmp/axterminator_element_screenshot_{}.png",
-            std::process::id()
+        let temp_dir = tempfile::Builder::new()
+            .prefix("axterminator_element_screenshot_")
+            .tempdir()
+            .map_err(|e| AXError::SystemError(e.to_string()))?;
+        let temp_path = temp_dir.path().join("capture.png");
+        let region = format!(
+            "{},{},{},{}",
+            x as i32, y as i32, width as i32, height as i32
         );
 
         let output = Command::new("screencapture")
-            .args([
-                "-R",
-                &format!(
-                    "{},{},{},{}",
-                    x as i32, y as i32, width as i32, height as i32
-                ),
-                "-x",
-                &temp_path,
-            ])
+            .arg("-R")
+            .arg(&region)
+            .arg("-x")
+            .arg(&temp_path)
             .output()
             .map_err(|e| AXError::SystemError(e.to_string()))?;
 
@@ -381,7 +381,6 @@ impl AXElement {
         }
 
         let data = std::fs::read(&temp_path).map_err(|e| AXError::SystemError(e.to_string()))?;
-        let _ = std::fs::remove_file(&temp_path);
 
         Ok(data)
     }

--- a/src/healing.rs
+++ b/src/healing.rs
@@ -617,11 +617,19 @@ fn capture_window_screenshot(root: AXUIElementRef) -> Option<Vec<u8>> {
 
     let window_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
-    // Capture screenshot to temp file
-    let temp_path = format!("/tmp/axterminator_vlm_screenshot_{}.png", pid);
+    // Capture screenshot to a private temp directory.
+    let temp_dir = tempfile::Builder::new()
+        .prefix("axterminator_vlm_screenshot_")
+        .tempdir()
+        .ok()?;
+    let temp_path = temp_dir.path().join("capture.png");
 
     let capture_result = Command::new("screencapture")
-        .args(["-l", &window_id, "-o", "-x", &temp_path])
+        .arg("-l")
+        .arg(&window_id)
+        .arg("-o")
+        .arg("-x")
+        .arg(&temp_path)
         .output()
         .ok()?;
 
@@ -631,7 +639,6 @@ fn capture_window_screenshot(root: AXUIElementRef) -> Option<Vec<u8>> {
 
     // Read the screenshot data
     let data = std::fs::read(&temp_path).ok()?;
-    let _ = std::fs::remove_file(&temp_path);
 
     Some(data)
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -148,8 +148,9 @@ impl SceneGraph {
     }
 
     /// Append a node and return its assigned [`NodeId`].
-    pub(crate) fn push(&mut self, node: SceneNode) -> NodeId {
+    pub(crate) fn push(&mut self, mut node: SceneNode) -> NodeId {
         let id = NodeId(self.nodes.len());
+        node.id = id;
         self.nodes.push(node);
         id
     }
@@ -204,33 +205,85 @@ pub fn scan_scene_bounded(root_element: AXUIElementRef, max_nodes: usize) -> AXR
     }
 
     let mut graph = SceneGraph::default();
-    let mut queue: VecDeque<(AXUIElementRef, Option<NodeId>, usize)> = VecDeque::new();
-    queue.push_back((root_element, None, 0));
+    let mut queue: VecDeque<QueuedElement> = VecDeque::new();
+    queue.push_back(QueuedElement::borrowed(root_element, None, 0));
 
-    while let Some((elem_ref, parent_id, depth)) = queue.pop_front() {
-        if graph.len() >= max_nodes {
+    while graph.len() < max_nodes {
+        let Some(queued) = queue.pop_front() else {
             break;
-        }
+        };
 
-        let node = snapshot_element(elem_ref, parent_id, depth);
+        let node = snapshot_element(queued.element, queued.parent, queued.depth);
         let node_id = graph.push(node);
 
         // Register this child with its parent
-        if let Some(pid) = parent_id {
+        if let Some(pid) = queued.parent {
             if let Some(parent) = graph.get_mut(pid) {
                 parent.children.push(node_id);
             }
         }
 
-        // Enqueue children — release each retained ref after enqueue
-        if let Ok(children) = accessibility::get_children(elem_ref) {
+        // Enqueue children. get_children() returns +1 retained refs; the queue
+        // tracks ownership so each child is released after it is snapshotted.
+        if let Ok(children) = accessibility::get_children(queued.element) {
             for child_ref in children {
-                queue.push_back((child_ref, Some(node_id), depth + 1));
+                queue.push_back(QueuedElement::owned(
+                    child_ref,
+                    Some(node_id),
+                    queued.depth + 1,
+                ));
             }
+        }
+
+        queued.release_if_owned();
+    }
+
+    release_queued_elements(queue);
+
+    Ok(graph)
+}
+
+/// Work item for [`scan_scene_bounded`].
+///
+/// The root element is borrowed from the caller. Child refs returned by
+/// `accessibility::get_children` are retained and must be released after use.
+struct QueuedElement {
+    element: AXUIElementRef,
+    parent: Option<NodeId>,
+    depth: usize,
+    owned: bool,
+}
+
+impl QueuedElement {
+    fn borrowed(element: AXUIElementRef, parent: Option<NodeId>, depth: usize) -> Self {
+        Self {
+            element,
+            parent,
+            depth,
+            owned: false,
         }
     }
 
-    Ok(graph)
+    fn owned(element: AXUIElementRef, parent: Option<NodeId>, depth: usize) -> Self {
+        Self {
+            element,
+            parent,
+            depth,
+            owned: true,
+        }
+    }
+
+    fn release_if_owned(self) {
+        if self.owned {
+            accessibility::release_cf(self.element.cast());
+        }
+    }
+}
+
+fn release_queued_elements(queue: VecDeque<QueuedElement>) {
+    for queued in queue {
+        queued.release_if_owned();
+    }
 }
 
 /// Snapshot a single element into a [`SceneNode`] without retaining any CF refs.
@@ -403,11 +456,13 @@ mod tests {
     fn scene_graph_push_assigns_sequential_ids() {
         // GIVEN: Two nodes
         let mut graph = SceneGraph::empty();
-        let id0 = graph.push(make_button(0, "OK"));
-        let id1 = graph.push(make_button(1, "Cancel"));
+        let id0 = graph.push(make_button(99, "OK"));
+        let id1 = graph.push(make_button(42, "Cancel"));
         // THEN: IDs are 0 and 1
         assert_eq!(id0, NodeId(0));
         assert_eq!(id1, NodeId(1));
+        assert_eq!(graph.get(id0).unwrap().id, NodeId(0));
+        assert_eq!(graph.get(id1).unwrap().id, NodeId(1));
     }
 
     #[test]

--- a/src/mcp/annotations.rs
+++ b/src/mcp/annotations.rs
@@ -1,8 +1,11 @@
 //! Canonical tool annotations for every Phase 1 and Phase 2 tool.
 //!
-//! Each constant captures the semantic hints defined in MCP 2025-11-05 §6.3.
-//! Centralising them here ensures the CLI help text and MCP `tools/list` response
-//! stay consistent with the design document.
+//! Each constant captures the semantic hints defined in MCP 2025-11-25 §6.3
+//! (the four hint fields are unchanged from 2025-11-05; the per-tool
+//! `title` field added in 2025-11-25 is already covered by `Tool.title`,
+//! so `ToolAnnotations.title` stays implicit).
+//! Centralising them here ensures the CLI help text and MCP `tools/list`
+//! response stay consistent with the design document.
 //!
 //! ## Annotation semantics
 //!

--- a/src/mcp/prompts.rs
+++ b/src/mcp/prompts.rs
@@ -438,7 +438,7 @@ Here's a troubleshooting guide based on common AXTerminator issues:\n\
 ## Screenshot fails silently\n\
 1. ax_screenshot uses a window-id lookup that may fail on some apps\n\
 2. Fallback: use screencapture CLI with region coordinates from ax_list_windows\n\
-3. Example: screencapture -R\"x,y,w,h\" -x /tmp/shot.png\n\
+3. Example: tmp=$(mktemp \"${TMPDIR:-/tmp}/axterminator-shot.XXXXXX.png\"); screencapture -R\"x,y,w,h\" -x \"$tmp\"\n\
 \n\
 ## App not found\n\
 1. Run ax_list_apps to see exact running app names\n\

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -1,4 +1,4 @@
-//! MCP 2025-11-05 protocol types.
+//! MCP 2025-11-25 protocol types (wire-compatible with 2025-11-05).
 //!
 //! Covers the wire types for Phase 1, Phase 2, and Phase 5 (Tasks API):
 //! - `initialize` handshake with resources + prompts + tasks capabilities
@@ -299,7 +299,8 @@ pub struct Tool {
     pub annotations: ToolAnnotations,
 }
 
-/// Semantic hints for MCP clients (MCP 2025-11-05 §6.3).
+/// Semantic hints for MCP clients (MCP 2025-11-25 §6.3; four hint fields
+/// are unchanged from 2025-11-05).
 ///
 /// These four boolean fields are a direct serialisation of the MCP wire format —
 /// each maps to a distinct JSON property. Refactoring into an enum would break

--- a/src/mcp/security.rs
+++ b/src/mcp/security.rs
@@ -210,6 +210,12 @@ impl AppPolicy {
         self.allowed.is_empty() || self.allowed.contains(app_id)
     }
 
+    /// Return true when no allow/deny policy is configured.
+    #[must_use]
+    pub fn is_permissive(&self) -> bool {
+        self.allowed.is_empty() && self.denied.is_empty()
+    }
+
     /// A permissive policy that allows every application.
     #[must_use]
     pub fn permissive() -> Self {
@@ -227,7 +233,7 @@ impl AppPolicy {
     /// allowed = ["Calculator", "com.apple.Safari"]
     /// denied  = ["com.apple.Keychain-Access"]
     /// ```
-    fn parse(content: &str) -> Self {
+    pub(crate) fn parse(content: &str) -> Self {
         let mut allowed = HashSet::new();
         let mut denied = HashSet::new();
 
@@ -446,6 +452,12 @@ impl SecurityGuard {
         }
     }
 
+    /// Return true when no app allow/deny policy is configured.
+    #[must_use]
+    pub fn app_policy_is_permissive(&self) -> bool {
+        self.app_policy.is_permissive()
+    }
+
     /// Append an audit record for a completed mutating tool call.
     ///
     /// No-op for read-only tools (determined by [`is_mutating_tool`]).
@@ -624,6 +636,7 @@ mod tests {
         let policy = AppPolicy::permissive();
         assert!(policy.is_app_allowed("Calculator"));
         assert!(policy.is_app_allowed("com.apple.Keychain-Access"));
+        assert!(policy.is_permissive());
     }
 
     #[test]
@@ -634,6 +647,7 @@ mod tests {
         assert!(!policy.is_app_allowed("1Password"));
         // THEN: others still allowed
         assert!(policy.is_app_allowed("Calculator"));
+        assert!(!policy.is_permissive());
     }
 
     #[test]
@@ -644,6 +658,7 @@ mod tests {
         assert!(policy.is_app_allowed("Calculator"));
         // THEN: Safari blocked
         assert!(!policy.is_app_allowed("Safari"));
+        assert!(!policy.is_permissive());
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -254,9 +254,9 @@ impl Server {
 
 /// A public wrapper around [`Server`] for use by the HTTP transport layer.
 ///
-/// Each HTTP request creates its own `ServerHandle` (stateless per-request
-/// in Phase 4). Stateful HTTP sessions — where connected apps persist across
-/// requests — are deferred to Phase 5.
+/// The HTTP transport stores one `ServerHandle` in its shared application state
+/// so MCP lifecycle, connected apps, workflow state, and subscriptions persist
+/// across the request sequence for a server process.
 ///
 /// # Examples
 ///

--- a/src/mcp/server_handlers.rs
+++ b/src/mcp/server_handlers.rs
@@ -531,6 +531,12 @@ impl Server {
                 }
             }
         }
+        if name == "ax_click_at" && !self.security.app_policy_is_permissive() {
+            return crate::mcp::protocol::ToolCallResult::error(
+                "Tool 'ax_click_at' is blocked while an app allow/deny policy is configured \
+                 because coordinate clicks cannot be scoped to an allowed app",
+            );
+        }
 
         // Execute.
         #[cfg(feature = "watch")]
@@ -791,5 +797,29 @@ Use prompts/get for detailed guidance:\n\
 - 'automate-workflow' — tracked workflow planning guidance\n\
 - 'analyze-app' — comprehensive UI analysis\n\
 - 'test-app' / 'navigate-to' / 'extract-data' / 'accessibility-audit'",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::mcp::security::AppPolicy;
+
+    use super::*;
+
+    #[test]
+    fn coordinate_click_is_blocked_when_app_policy_is_configured() {
+        let mut server = Server::new();
+        server.security.app_policy = AppPolicy::parse("allowed = [\"Calculator\"]");
+
+        let mut out = Vec::new();
+        let result = server.dispatch_tool("ax_click_at", &json!({"x": 0, "y": 0}), &mut out);
+
+        assert!(result.is_error);
+        assert!(result.content[0]
+            .text
+            .contains("cannot be scoped to an allowed app"));
+        assert!(out.is_empty());
     }
 }

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -151,7 +151,7 @@ fn serve_stdio() -> anyhow::Result<()> {
 mod http {
     use std::convert::Infallible;
     use std::net::SocketAddr;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use axum::extract::{ConnectInfo, State};
@@ -178,9 +178,14 @@ mod http {
     const SSE_KEEPALIVE: Duration = Duration::from_secs(15);
 
     /// Shared state injected into every request handler.
-    #[derive(Clone)]
     pub(super) struct AppState {
         validator: BearerValidator,
+        /// Persistent MCP session state shared by all HTTP requests.
+        ///
+        /// MCP lifecycle, connected apps, tasks, workflows, and subscriptions
+        /// all live inside `ServerHandle`; recreating it per request breaks the
+        /// initialize -> initialized -> tools/call sequence used by clients.
+        server: Mutex<crate::mcp::server::ServerHandle>,
         /// Broadcast channel for server-initiated notifications.
         sse_tx: broadcast::Sender<SseEvent>,
     }
@@ -197,7 +202,11 @@ mod http {
     impl AppState {
         pub fn new(validator: BearerValidator) -> Self {
             let (sse_tx, _) = broadcast::channel(SSE_CHANNEL_CAPACITY);
-            Self { validator, sse_tx }
+            Self {
+                validator,
+                server: Mutex::new(crate::mcp::server::ServerHandle::new()),
+                sse_tx,
+            }
         }
     }
 
@@ -284,13 +293,12 @@ mod http {
         };
 
         let mut sink = Vec::<u8>::new();
-        let maybe_resp = {
-            // Server state is not shared across HTTP requests in Phase 4 —
-            // each request gets its own ephemeral server instance. Stateful
-            // sessions (connected apps persisting across requests) are a
-            // Phase 5 feature. This keeps Phase 4 correct and simple.
-            let mut server = crate::mcp::server::ServerHandle::new();
-            server.handle(&rpc_req, &mut sink)
+        let maybe_resp = match state.server.lock() {
+            Ok(mut server) => server.handle(&rpc_req, &mut sink),
+            Err(e) => {
+                error!("MCP HTTP server state lock poisoned: {e}");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
         };
 
         // Forward any SSE notifications that were written to the sink.
@@ -453,6 +461,85 @@ mod http {
     async fn shutdown_signal() {
         let _ = tokio::signal::ctrl_c().await;
         info!("shutdown signal received");
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        use axum::body::to_bytes;
+        use serde_json::json;
+
+        use crate::mcp::auth::AuthConfig;
+
+        use super::*;
+
+        async fn post_json(state: Arc<AppState>, body: Value) -> (StatusCode, Value) {
+            let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 49152);
+            let response = post_mcp(
+                ConnectInfo(peer),
+                State(state),
+                HeaderMap::new(),
+                Json(body),
+            )
+            .await;
+            let status = response.status();
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let value = if body.is_empty() {
+                Value::Null
+            } else {
+                serde_json::from_slice(&body).unwrap()
+            };
+            (status, value)
+        }
+
+        #[tokio::test]
+        async fn post_mcp_reuses_server_state_across_requests() {
+            let validator = BearerValidator::new(AuthConfig::localhost_only());
+            let state = Arc::new(AppState::new(validator));
+
+            let (status, init) = post_json(
+                Arc::clone(&state),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-05",
+                        "capabilities": {},
+                        "clientInfo": {"name": "http-test", "version": "1"}
+                    }
+                }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(init["result"]["protocolVersion"], "2025-11-05");
+
+            let (status, notification) = post_json(
+                Arc::clone(&state),
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/initialized"
+                }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+            assert_eq!(notification, Value::Null);
+
+            let (status, tools) = post_json(
+                Arc::clone(&state),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list"
+                }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            assert!(tools["result"]["tools"]
+                .as_array()
+                .is_some_and(|tools| !tools.is_empty()));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Persist MCP HTTP server state across request lifecycle.
- Block coordinate clicks when app policy scoping is configured.
- Replace predictable temp paths with private temp files/directories.
- Randomize Neko admin password and bind browser ports to loopback.
- Fix SceneGraph node IDs and queued AX child-ref cleanup.
- Update docs and add CI benchmark type-checking.

## DoD Evidence
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo check`
- `RUSTC_WRAPPER= cargo check --no-default-features`
- `RUSTC_WRAPPER= cargo check --all-features`
- `RUSTC_WRAPPER= cargo check --benches`
- `RUSTC_WRAPPER= cargo clippy --all-features --all-targets -- -D warnings -A unexpected_cfgs`
- `RUSTC_WRAPPER= cargo test --all-features -- --skip live_`
- `RUSTC_WRAPPER= cargo audit`
- `git diff --check`
- `trufflehog git file://. --only-verified`

## DoR / DoD Notes
- DoR: scope and targets are explicit from the repo-analysis closeout: MCP lifecycle, app-policy safety, temp-file handling, Docker browser hardening, SceneGraph correctness, docs, and CI.
- DoD: local gates are green; PR CI still needs GitHub confirmation after creation.
- D6 size: existing files over 800 LOC remain a warning/follow-up, not introduced by this patch.
- Tracking issue comment was not posted because no issue ID was provided.

## Impact
Improves MCP HTTP correctness, security scoping, temporary-file safety, Docker browser defaults, and CI coverage for benchmark buildability.