### PR TITLE
feat: add enhanced TTS engine routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,11 @@ docker = []
 #     --local-dir ~/.axterminator/models/parakeet-tdt-0.6b-v3
 # The `ort` crate uses pre-built ONNX Runtime binaries (no manual SDK install).
 parakeet = ["audio", "dep:ort"]
+# enhanced-tts: optional higher-quality TTS routing for Kokoro and Piper via
+# sherpa-onnx model bundles.  Requires the `audio` feature but adds no default
+# dependency or model weight to the normal binary; model files are downloaded
+# on demand with `axterminator models tts download`.
+enhanced-tts = ["audio"]
 
 [dependencies]
 # CLI (feature-gated so it's only compiled for the binary target)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Done. Your agent has 27 core tools (up to 34+ with all feature flags) to control
 | **Observe** | `ax_is_accessible`, `ax_screenshot`, `ax_get_tree`, `ax_get_attributes`, `ax_list_windows`, `ax_list_apps`, `ax_wait_idle` | Check permissions, see UI state, screenshots |
 | **Verify** | `ax_assert`, `ax_find_visual`, `ax_visual_diff`, `ax_a11y_audit` | Assert element state, AI vision fallback, visual regression, WCAG audit |
 | **System** | `ax_clipboard`, `ax_run_script`, `ax_undo`, `ax_session_info`, `ax_analyze` | Clipboard, AppleScript/JXA, undo actions, session state, UI analysis |
-| **Audio** | `ax_listen`, `ax_speak`, `ax_audio_voices`, `ax_audio_devices` | Capture mic/system audio, text-to-speech, inspect installed macOS voices |
+| **Audio** | `ax_listen`, `ax_speak`, `ax_audio_voices`, `ax_audio_devices` | Capture mic/system audio, text-to-speech, inspect installed macOS voices; optional Kokoro/Piper TTS via `enhanced-tts` |
 | **Camera** | `ax_camera_capture`, `ax_gesture_detect`, `ax_gesture_listen` | Camera frames, gesture recognition |
 | **Spaces** | `ax_list_spaces`, `ax_create_space`, `ax_move_to_space`, `ax_switch_space`, `ax_destroy_space` | Virtual desktop isolation |
 
@@ -235,13 +235,14 @@ Yes. Add `axterminator mcp install --client codex` (or `--client claude-code`, e
 The Homebrew formula includes all features. When building from source, select capabilities with feature flags:
 
 ```bash
-cargo build --release --features "cli,audio,camera,spaces"
+cargo build --release --features "cli,audio,enhanced-tts,camera,spaces"
 ```
 
 | Flag | What |
 |------|------|
 | `cli` | CLI + MCP server (default) |
 | `audio` | Microphone/system audio, speech |
+| `enhanced-tts` | Optional Kokoro/Piper TTS engine routing and `axterminator models tts` downloads |
 | `camera` | Camera capture, gesture detection |
 | `spaces` | Virtual desktop management |
 | `http-transport` | HTTP MCP transport with auth |

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -38,12 +38,13 @@ AXTerminator v0.6.1 exposes up to 30 MCP tools (19 core + optional audio, camera
 | `ax_assert` | Assert element state (exists, enabled, value, etc.) | readOnly |
 | `ax_find_visual` | Find element using VLM vision as fallback | readOnly |
 
-## Audio Tools (3) -- `audio` feature
+## Audio Tools (4) -- `audio` feature
 
 | Tool | Description | Annotations |
 |------|-------------|-------------|
 | `ax_listen` | Capture audio and transcribe via SFSpeechRecognizer (48kHz native) | readOnly |
-| `ax_speak` | Text-to-speech via NSSpeechSynthesizer | openWorld |
+| `ax_speak` | Text-to-speech via system, Kokoro, or Piper engines | openWorld |
+| `ax_audio_voices` | List installed macOS speech voices | readOnly |
 | `ax_audio_devices` | List available audio input/output devices | readOnly |
 
 ## Camera Tools (3) -- `camera` feature

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,7 +50,10 @@ cd axterminator
 cargo build --release --features cli
 
 # With all optional features
-cargo build --release --features "cli,audio,camera,spaces"
+cargo build --release --features "cli,audio,enhanced-tts,camera,spaces"
+
+# With optional enhanced TTS model management
+cargo build --release --features "cli,enhanced-tts"
 ```
 
 ## Verify Installation

--- a/docs/guide/audio.md
+++ b/docs/guide/audio.md
@@ -1,6 +1,6 @@
 # Audio & Speech
 
-AXTerminator includes on-device audio capture and speech recognition via the `audio` feature flag.
+AXTerminator includes on-device audio capture, speech recognition, and text-to-speech via the `audio` feature flag.
 
 ## Enable Audio
 
@@ -15,7 +15,8 @@ cargo build --release --features "cli,audio"
 | Tool | Description |
 |------|-------------|
 | `ax_listen` | Capture microphone or system audio, transcribe via SFSpeechRecognizer |
-| `ax_speak` | Text-to-speech via NSSpeechSynthesizer |
+| `ax_speak` | Text-to-speech via system, Kokoro, or Piper engines |
+| `ax_audio_voices` | List installed macOS speech voices |
 | `ax_audio_devices` | List available audio input/output devices |
 
 ## Speech Recognition
@@ -39,12 +40,30 @@ AXTerminator captures audio at **native 48kHz sample rate** and transcribes on-d
 
 ## Text-to-Speech
 
-```bash
-# Via CLI
-axterminator speak "Hello from AXTerminator"
+`ax_speak` defaults to the existing macOS `NSSpeechSynthesizer` path:
+
+```json
+{"text": "Hello from AXTerminator"}
 ```
 
-Uses NSSpeechSynthesizer with the system default voice.
+To opt into local neural engines, build with `enhanced-tts`, install the
+external `sherpa-onnx-offline-tts` runtime, and download model files on demand:
+
+```bash
+cargo build --release --features "cli,enhanced-tts"
+axterminator models tts list
+axterminator models tts download kokoro
+axterminator models tts download piper
+```
+
+Then call:
+
+```json
+{"text": "Hello from AXTerminator", "engine": "kokoro", "voice": "af_heart"}
+```
+
+If an enhanced engine is requested but its model files are missing, `ax_speak`
+falls back to `system` and returns `fallback_reason`.
 
 ## Audio Devices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ Done. Your agent has 27 core tools (up to 34+ with all feature flags) to control
 | **Observe** | `ax_is_accessible`, `ax_screenshot`, `ax_get_tree`, `ax_get_attributes`, `ax_list_windows`, `ax_list_apps`, `ax_wait_idle` | Check permissions, see UI state, screenshots |
 | **Verify** | `ax_assert`, `ax_find_visual`, `ax_visual_diff`, `ax_a11y_audit` | Assert element state, AI vision fallback, visual regression, WCAG audit |
 | **System** | `ax_clipboard`, `ax_run_script`, `ax_undo`, `ax_session_info`, `ax_analyze` | Clipboard, AppleScript/JXA, undo actions, session state, UI analysis |
-| **Audio** | `ax_listen`, `ax_speak`, `ax_audio_devices` | Capture mic/system audio (48kHz native), text-to-speech |
+| **Audio** | `ax_listen`, `ax_speak`, `ax_audio_voices`, `ax_audio_devices` | Capture mic/system audio (48kHz native), text-to-speech; optional Kokoro/Piper via `enhanced-tts` |
 | **Camera** | `ax_camera_capture`, `ax_gesture_detect`, `ax_gesture_listen` | Camera frames, gesture recognition |
 | **Spaces** | `ax_list_spaces`, `ax_create_space`, `ax_move_to_space`, `ax_switch_space`, `ax_destroy_space` | Virtual desktop isolation |
 
@@ -99,13 +99,14 @@ Destructive actions require confirmation via elicitation. HTTP transport require
 Build with optional capabilities:
 
 ```bash
-cargo build --release --features "cli,audio,camera,spaces"
+cargo build --release --features "cli,audio,enhanced-tts,camera,spaces"
 ```
 
 | Flag | What |
 |------|------|
 | `cli` | CLI + MCP server (default) |
 | `audio` | Microphone/system audio, speech recognition (48kHz native capture) |
+| `enhanced-tts` | Optional Kokoro/Piper TTS engine routing and `axterminator models tts` downloads |
 | `camera` | Camera capture, gesture detection (88.8% thumbs_up verified) |
 | `watch` | Continuous background monitoring (implies audio + camera) |
 | `spaces` | Virtual desktop management (CGSSpace private API) |

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -7,7 +7,7 @@
 //! | Microphone capture | `AVAudioEngine` (CoreAudio) | Requires TCC microphone permission |
 //! | System audio capture | `ScreenCaptureKit` (macOS 14+) | No Screen Recording permission needed |
 //! | Speech-to-text | `SFSpeechRecognizer` | On-device only — no cloud |
-//! | Text-to-speech | `NSSpeechSynthesizer` | No network; local voice synthesis |
+//! | Text-to-speech | `NSSpeechSynthesizer`, optional Kokoro/Piper | No network during synthesis |
 //!
 //! ## Quick start
 //!
@@ -53,6 +53,7 @@
 //! ## Security
 //!
 //! - Speech recognition prefers on-device models (server fallback if model not downloaded).
+//! - Enhanced TTS model files are downloaded only when explicitly requested.
 //! - No audio data leaves the machine (when on-device model is available).
 //! - Temporary WAV files (when used) are written to `/tmp` with mode `0600`
 //!   and deleted immediately after encoding.
@@ -71,6 +72,8 @@ mod ffi;
 pub mod parakeet;
 mod sck_capture;
 mod speech;
+#[cfg(feature = "enhanced-tts")]
+pub mod tts_models;
 
 // ---------------------------------------------------------------------------
 // Public re-exports
@@ -79,7 +82,8 @@ mod speech;
 pub use capture::{capture_microphone, capture_system_audio, validate_duration};
 pub use devices::{AudioDevice, check_microphone_permission, list_audio_devices};
 pub use speech::{
-    AudioEngine, list_speech_voices, speak, speak_with_voice, transcribe, transcribe_with_engine,
+    AudioEngine, TtsEngine, TtsSpeakResult, list_speech_voices, speak, speak_with_engine,
+    speak_with_voice, transcribe, transcribe_with_engine,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/audio/speech.rs
+++ b/src/audio/speech.rs
@@ -108,6 +108,62 @@ impl AudioEngine {
     }
 }
 
+/// Text-to-speech engine selector.
+///
+/// `System` keeps the existing `NSSpeechSynthesizer` behavior.  `Kokoro` and
+/// `Piper` are optional enhanced engines that require the `enhanced-tts`
+/// feature plus downloaded model files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TtsEngine {
+    /// Apple `NSSpeechSynthesizer` — on-device, macOS built-in.
+    #[default]
+    System,
+    /// Kokoro 82M TTS model bundle through `sherpa-onnx-offline-tts`.
+    Kokoro,
+    /// Piper TTS model bundle through `sherpa-onnx-offline-tts`.
+    Piper,
+}
+
+impl TtsEngine {
+    /// Parse a TTS engine name from a string slice (case-insensitive).
+    ///
+    /// Accepts `"system"`, `"kokoro"`, and `"piper"`.
+    #[must_use]
+    pub fn parse_str(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "system" => Some(Self::System),
+            "kokoro" => Some(Self::Kokoro),
+            "piper" => Some(Self::Piper),
+            _ => None,
+        }
+    }
+
+    /// Machine-readable name of the engine.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::Kokoro => "kokoro",
+            Self::Piper => "piper",
+        }
+    }
+}
+
+/// Result metadata for a TTS request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TtsSpeakResult {
+    /// Blocking wall-clock duration of synthesis and playback.
+    pub elapsed: Duration,
+    /// Engine requested by the caller.
+    pub requested_engine: TtsEngine,
+    /// Engine actually used after any fallback.
+    pub engine_used: TtsEngine,
+    /// Voice identifier or model speaker name/ID used for synthesis.
+    pub voice_used: String,
+    /// Reason for falling back to system TTS.
+    pub fallback_reason: Option<String>,
+}
+
 /// Transcribe audio on-device using `SFSpeechRecognizer`.
 ///
 /// All recognition runs locally (`requiresOnDeviceRecognition = true`).
@@ -237,6 +293,104 @@ pub fn speak_with_voice(text: &str, voice: Option<&str>) -> Result<Duration, Aud
         "speaking text"
     );
     speak_with_ns_speech_synthesizer(text, voice)
+}
+
+/// Synthesize `text` with a selected TTS engine.
+///
+/// When `engine` is [`TtsEngine::System`], this is the same path used by
+/// [`speak_with_voice`].  Enhanced engines fall back to `System` when their
+/// model files are not installed, preserving compatibility for callers that
+/// opt into a better voice before downloading local model weights.
+pub fn speak_with_engine(
+    text: &str,
+    voice: Option<&str>,
+    engine: TtsEngine,
+) -> Result<TtsSpeakResult, AudioError> {
+    if text.is_empty() {
+        return Err(AudioError::Synthesis(
+            "Cannot speak empty string".to_string(),
+        ));
+    }
+
+    match engine {
+        TtsEngine::System => speak_with_system_engine(text, voice, TtsEngine::System, None),
+        TtsEngine::Kokoro | TtsEngine::Piper => try_speak_with_enhanced_engine(text, voice, engine),
+    }
+}
+
+fn speak_with_system_engine(
+    text: &str,
+    voice: Option<&str>,
+    requested_engine: TtsEngine,
+    fallback_reason: Option<String>,
+) -> Result<TtsSpeakResult, AudioError> {
+    let elapsed = speak_with_voice(text, voice)?;
+    Ok(TtsSpeakResult {
+        elapsed,
+        requested_engine,
+        engine_used: TtsEngine::System,
+        voice_used: voice
+            .map(str::trim)
+            .filter(|candidate| !candidate.is_empty())
+            .unwrap_or("system-default")
+            .to_string(),
+        fallback_reason,
+    })
+}
+
+#[cfg(feature = "enhanced-tts")]
+fn try_speak_with_enhanced_engine(
+    text: &str,
+    voice: Option<&str>,
+    engine: TtsEngine,
+) -> Result<TtsSpeakResult, AudioError> {
+    let missing = crate::audio::tts_models::missing_model_files(engine)?;
+    if !missing.is_empty() {
+        return speak_with_system_engine(
+            text,
+            voice,
+            engine,
+            Some(format!(
+                "{} model files not downloaded (missing: {})",
+                engine.as_str(),
+                missing.join(", ")
+            )),
+        );
+    }
+
+    let elapsed = crate::audio::tts_models::speak_with_sherpa(text, voice, engine)?;
+    Ok(TtsSpeakResult {
+        elapsed,
+        requested_engine: engine,
+        engine_used: engine,
+        voice_used: voice
+            .map(str::trim)
+            .filter(|candidate| !candidate.is_empty())
+            .unwrap_or(match engine {
+                TtsEngine::Kokoro => "af_heart",
+                TtsEngine::Piper => "en_US-lessac-medium",
+                TtsEngine::System => "system-default",
+            })
+            .to_string(),
+        fallback_reason: None,
+    })
+}
+
+#[cfg(not(feature = "enhanced-tts"))]
+fn try_speak_with_enhanced_engine(
+    text: &str,
+    voice: Option<&str>,
+    engine: TtsEngine,
+) -> Result<TtsSpeakResult, AudioError> {
+    speak_with_system_engine(
+        text,
+        voice,
+        engine,
+        Some(format!(
+            "{} requires the `enhanced-tts` Cargo feature; used system TTS",
+            engine.as_str()
+        )),
+    )
 }
 
 /// Return the installed macOS speech voice identifiers.
@@ -754,6 +908,35 @@ mod tests {
     #[test]
     fn audio_engine_default_is_apple() {
         assert_eq!(AudioEngine::default(), AudioEngine::Apple);
+    }
+
+    // -----------------------------------------------------------------------
+    // TtsEngine parsing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tts_engine_from_str_system() {
+        assert_eq!(TtsEngine::parse_str("system"), Some(TtsEngine::System));
+        assert_eq!(TtsEngine::parse_str("SYSTEM"), Some(TtsEngine::System));
+    }
+
+    #[test]
+    fn tts_engine_from_str_kokoro_and_piper() {
+        assert_eq!(TtsEngine::parse_str("kokoro"), Some(TtsEngine::Kokoro));
+        assert_eq!(TtsEngine::parse_str("piper"), Some(TtsEngine::Piper));
+    }
+
+    #[test]
+    fn tts_engine_from_str_unknown_returns_none() {
+        assert_eq!(TtsEngine::parse_str("festival"), None);
+        assert_eq!(TtsEngine::parse_str(""), None);
+    }
+
+    #[test]
+    fn tts_engine_as_str_round_trips() {
+        assert_eq!(TtsEngine::System.as_str(), "system");
+        assert_eq!(TtsEngine::Kokoro.as_str(), "kokoro");
+        assert_eq!(TtsEngine::Piper.as_str(), "piper");
     }
 
     // -----------------------------------------------------------------------

--- a/src/audio/tts_models.rs
+++ b/src/audio/tts_models.rs
@@ -1,0 +1,474 @@
+//! Model registry and external runtime bridge for enhanced TTS engines.
+//!
+//! The large model artifacts are never bundled into the binary.  This module
+//! only stores small model metadata, checks the local model cache, and invokes
+//! `sherpa-onnx-offline-tts` when the user explicitly requests a non-system
+//! TTS engine.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use super::{AudioError, TtsEngine};
+
+const KOKORO_REQUIRED_FILES: &[&str] = &[
+    "model.onnx",
+    "voices.bin",
+    "tokens.txt",
+    "espeak-ng-data",
+    "lexicon-us-en.txt",
+];
+
+const PIPER_REQUIRED_FILES: &[&str] = &["en_US-lessac-medium.onnx", "tokens.txt", "espeak-ng-data"];
+
+const KOKORO_SPEAKERS: &[(&str, u16)] = &[
+    ("af_alloy", 0),
+    ("af_aoede", 1),
+    ("af_bella", 2),
+    ("af_heart", 3),
+    ("af_jessica", 4),
+    ("af_kore", 5),
+    ("af_nicole", 6),
+    ("af_nova", 7),
+    ("af_river", 8),
+    ("af_sarah", 9),
+    ("af_sky", 10),
+    ("am_adam", 11),
+    ("am_echo", 12),
+    ("am_eric", 13),
+    ("am_fenrir", 14),
+    ("am_liam", 15),
+    ("am_michael", 16),
+    ("am_onyx", 17),
+    ("am_puck", 18),
+    ("am_santa", 19),
+    ("bf_alice", 20),
+    ("bf_emma", 21),
+    ("bf_isabella", 22),
+    ("bf_lily", 23),
+    ("bm_daniel", 24),
+    ("bm_fable", 25),
+    ("bm_george", 26),
+    ("bm_lewis", 27),
+    ("ef_dora", 28),
+    ("em_alex", 29),
+    ("ff_siwis", 30),
+    ("hf_alpha", 31),
+    ("hf_beta", 32),
+    ("hm_omega", 33),
+    ("hm_psi", 34),
+    ("if_sara", 35),
+    ("im_nicola", 36),
+    ("jf_alpha", 37),
+    ("jf_gongitsune", 38),
+    ("jf_nezumi", 39),
+    ("jf_tebukuro", 40),
+    ("jm_kumo", 41),
+    ("pf_dora", 42),
+    ("pm_alex", 43),
+    ("pm_santa", 44),
+    ("zf_xiaobei", 45),
+    ("zf_xiaoni", 46),
+    ("zf_xiaoxiao", 47),
+    ("zf_xiaoyi", 48),
+    ("zm_yunjian", 49),
+    ("zm_yunxi", 50),
+    ("zm_yunxia", 51),
+    ("zm_yunyang", 52),
+];
+
+/// Static metadata for an enhanced TTS model bundle.
+#[derive(Debug, Clone, Copy)]
+pub struct TtsModelSpec {
+    pub engine: TtsEngine,
+    pub display_name: &'static str,
+    pub directory: &'static str,
+    pub archive_url: &'static str,
+    pub docs_url: &'static str,
+    pub runtime_binary: &'static str,
+    pub required_files: &'static [&'static str],
+    pub description: &'static str,
+}
+
+/// Local installation status for a TTS model bundle.
+#[derive(Debug, Clone)]
+pub struct TtsModelStatus {
+    pub spec: &'static TtsModelSpec,
+    pub path: PathBuf,
+    pub installed: bool,
+    pub missing_files: Vec<String>,
+}
+
+/// Result returned by the model downloader.
+#[derive(Debug, Clone)]
+pub struct TtsModelDownload {
+    pub spec: &'static TtsModelSpec,
+    pub path: PathBuf,
+    pub downloaded: bool,
+}
+
+/// Model bundles supported by the enhanced TTS feature.
+pub const TTS_MODEL_SPECS: &[TtsModelSpec] = &[
+    TtsModelSpec {
+        engine: TtsEngine::Kokoro,
+        display_name: "Kokoro 82M multilingual",
+        directory: "kokoro",
+        archive_url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/kokoro-multi-lang-v1_0.tar.bz2",
+        docs_url: "https://k2-fsa.github.io/sherpa/onnx/tts/pretrained_models/kokoro.html",
+        runtime_binary: "sherpa-onnx-offline-tts",
+        required_files: KOKORO_REQUIRED_FILES,
+        description: "Natural local neural TTS with multi-speaker voice IDs.",
+    },
+    TtsModelSpec {
+        engine: TtsEngine::Piper,
+        display_name: "Piper en_US lessac medium",
+        directory: "piper",
+        archive_url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/vits-piper-en_US-lessac-medium.tar.bz2",
+        docs_url: "https://k2-fsa.github.io/sherpa/onnx/tts/pretrained_models/vits.html",
+        runtime_binary: "sherpa-onnx-offline-tts",
+        required_files: PIPER_REQUIRED_FILES,
+        description: "Lightweight local Piper voice packaged for sherpa-onnx.",
+    },
+];
+
+/// Resolve the model cache root.
+///
+/// Enhanced TTS models are stored under `~/.axterminator/models/tts/`.
+pub fn model_root() -> Result<PathBuf, AudioError> {
+    let home = std::env::var("HOME").map_err(|_| {
+        AudioError::Synthesis("Cannot determine $HOME for TTS model directory".to_string())
+    })?;
+    Ok(PathBuf::from(home)
+        .join(".axterminator")
+        .join("models")
+        .join("tts"))
+}
+
+/// Return the static model spec for an enhanced TTS engine.
+#[must_use]
+pub fn spec_for_engine(engine: TtsEngine) -> Option<&'static TtsModelSpec> {
+    TTS_MODEL_SPECS.iter().find(|spec| spec.engine == engine)
+}
+
+/// Return the local model directory for an enhanced TTS engine.
+pub fn model_dir(engine: TtsEngine) -> Result<PathBuf, AudioError> {
+    let spec = spec_for_engine(engine).ok_or_else(|| {
+        AudioError::Synthesis(format!(
+            "{} does not use the enhanced TTS model cache",
+            engine.as_str()
+        ))
+    })?;
+    Ok(model_root()?.join(spec.directory))
+}
+
+/// Return local installation status for each enhanced TTS engine.
+pub fn model_statuses() -> Result<Vec<TtsModelStatus>, AudioError> {
+    TTS_MODEL_SPECS
+        .iter()
+        .map(|spec| model_status_for_engine(spec.engine))
+        .collect()
+}
+
+/// Return local installation status for one enhanced TTS engine.
+pub fn model_status_for_engine(engine: TtsEngine) -> Result<TtsModelStatus, AudioError> {
+    let spec = spec_for_engine(engine).ok_or_else(|| {
+        AudioError::Synthesis(format!("Unknown enhanced TTS engine: {}", engine.as_str()))
+    })?;
+    let path = model_dir(engine)?;
+    let missing_files = missing_model_files_in_dir(&path, spec);
+    Ok(TtsModelStatus {
+        spec,
+        path,
+        installed: missing_files.is_empty(),
+        missing_files,
+    })
+}
+
+/// Return true when all required model files are present.
+pub fn model_files_present(engine: TtsEngine) -> bool {
+    model_status_for_engine(engine)
+        .map(|status| status.installed)
+        .unwrap_or(false)
+}
+
+/// Return the missing file names for an engine's model bundle.
+pub fn missing_model_files(engine: TtsEngine) -> Result<Vec<String>, AudioError> {
+    Ok(model_status_for_engine(engine)?.missing_files)
+}
+
+/// Download and extract an enhanced TTS model bundle.
+///
+/// The download uses the system `curl` and `tar` commands to avoid adding a
+/// network stack to the default binary.  The command is only reachable when the
+/// `enhanced-tts` feature is compiled in.
+pub fn download_model(engine: TtsEngine, force: bool) -> Result<TtsModelDownload, AudioError> {
+    let spec = spec_for_engine(engine).ok_or_else(|| {
+        AudioError::Synthesis(format!(
+            "Engine {} has no downloadable TTS model",
+            engine.as_str()
+        ))
+    })?;
+    let root = model_root()?;
+    let target_dir = root.join(spec.directory);
+
+    if target_dir.exists() && model_files_present(engine) && !force {
+        return Ok(TtsModelDownload {
+            spec,
+            path: target_dir,
+            downloaded: false,
+        });
+    }
+
+    if force && target_dir.exists() {
+        std::fs::remove_dir_all(&target_dir).map_err(|e| {
+            AudioError::Synthesis(format!("Failed to remove {}: {e}", target_dir.display()))
+        })?;
+    }
+
+    std::fs::create_dir_all(&target_dir).map_err(|e| {
+        AudioError::Synthesis(format!("Failed to create {}: {e}", target_dir.display()))
+    })?;
+
+    let archive_path = root.join(format!("{}.tar.bz2.download", spec.directory));
+    let curl_status = Command::new("curl")
+        .args(["--fail", "--location", "--show-error", "--output"])
+        .arg(&archive_path)
+        .arg(spec.archive_url)
+        .status()
+        .map_err(|e| AudioError::Synthesis(format!("Failed to start curl: {e}")))?;
+    if !curl_status.success() {
+        return Err(AudioError::Synthesis(format!(
+            "curl failed while downloading {} from {}",
+            spec.display_name, spec.archive_url
+        )));
+    }
+
+    let tar_status = Command::new("tar")
+        .arg("-xf")
+        .arg(&archive_path)
+        .arg("-C")
+        .arg(&target_dir)
+        .arg("--strip-components=1")
+        .status()
+        .map_err(|e| AudioError::Synthesis(format!("Failed to start tar: {e}")))?;
+    let _ = std::fs::remove_file(&archive_path);
+
+    if !tar_status.success() {
+        return Err(AudioError::Synthesis(format!(
+            "tar failed while extracting {} into {}",
+            spec.display_name,
+            target_dir.display()
+        )));
+    }
+
+    let status = model_status_for_engine(engine)?;
+    if !status.installed {
+        return Err(AudioError::Synthesis(format!(
+            "{} extracted but required files are missing: {}",
+            spec.display_name,
+            status.missing_files.join(", ")
+        )));
+    }
+
+    Ok(TtsModelDownload {
+        spec,
+        path: target_dir,
+        downloaded: true,
+    })
+}
+
+/// Synthesize speech with `sherpa-onnx-offline-tts` and play it through `afplay`.
+pub fn speak_with_sherpa(
+    text: &str,
+    voice: Option<&str>,
+    engine: TtsEngine,
+) -> Result<Duration, AudioError> {
+    let missing = missing_model_files(engine)?;
+    if !missing.is_empty() {
+        return Err(AudioError::Synthesis(format!(
+            "{} model files not downloaded (missing: {}). Run \
+             `axterminator models tts download {}` first.",
+            engine.as_str(),
+            missing.join(", "),
+            engine.as_str()
+        )));
+    }
+
+    let output = tempfile::Builder::new()
+        .prefix("axterminator-tts-")
+        .suffix(".wav")
+        .tempfile()
+        .map_err(|e| AudioError::Synthesis(format!("Failed to create temp WAV: {e}")))?;
+
+    let started = Instant::now();
+    let synth_output = build_sherpa_command(engine, voice, text, output.path())?
+        .output()
+        .map_err(|e| {
+            AudioError::Synthesis(format!(
+                "Failed to start {}. Install it or set AXTERMINATOR_SHERPA_ONNX_TTS: {e}",
+                sherpa_binary()
+            ))
+        })?;
+
+    if !synth_output.status.success() {
+        let stderr = String::from_utf8_lossy(&synth_output.stderr);
+        return Err(AudioError::Synthesis(format!(
+            "{} failed for {}: {}",
+            sherpa_binary(),
+            engine.as_str(),
+            stderr.trim()
+        )));
+    }
+
+    let play_status = Command::new("afplay")
+        .arg(output.path())
+        .status()
+        .map_err(|e| AudioError::Synthesis(format!("Failed to start afplay: {e}")))?;
+    if !play_status.success() {
+        return Err(AudioError::Synthesis(format!(
+            "afplay failed while playing {} output",
+            engine.as_str()
+        )));
+    }
+
+    Ok(started.elapsed())
+}
+
+fn missing_model_files_in_dir(path: &Path, spec: &TtsModelSpec) -> Vec<String> {
+    spec.required_files
+        .iter()
+        .filter(|file| !path.join(file).exists())
+        .map(|file| (*file).to_string())
+        .collect()
+}
+
+fn build_sherpa_command(
+    engine: TtsEngine,
+    voice: Option<&str>,
+    text: &str,
+    output_path: &Path,
+) -> Result<Command, AudioError> {
+    let dir = model_dir(engine)?;
+    let mut cmd = Command::new(sherpa_binary());
+    cmd.arg("--num-threads=2")
+        .arg(format!("--output-filename={}", output_path.display()));
+
+    match engine {
+        TtsEngine::Kokoro => {
+            let speaker = kokoro_speaker_id(voice)?;
+            let lexicons = [dir.join("lexicon-us-en.txt"), dir.join("lexicon-zh.txt")]
+                .iter()
+                .filter(|path| path.exists())
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            cmd.arg(format!(
+                "--kokoro-model={}",
+                dir.join("model.onnx").display()
+            ))
+            .arg(format!(
+                "--kokoro-voices={}",
+                dir.join("voices.bin").display()
+            ))
+            .arg(format!(
+                "--kokoro-tokens={}",
+                dir.join("tokens.txt").display()
+            ))
+            .arg(format!(
+                "--kokoro-data-dir={}",
+                dir.join("espeak-ng-data").display()
+            ))
+            .arg(format!("--sid={speaker}"));
+            if !lexicons.is_empty() {
+                cmd.arg(format!("--kokoro-lexicon={lexicons}"));
+            }
+        }
+        TtsEngine::Piper => {
+            cmd.arg(format!(
+                "--vits-model={}",
+                dir.join("en_US-lessac-medium.onnx").display()
+            ))
+            .arg(format!(
+                "--vits-tokens={}",
+                dir.join("tokens.txt").display()
+            ))
+            .arg(format!(
+                "--vits-data-dir={}",
+                dir.join("espeak-ng-data").display()
+            ));
+        }
+        TtsEngine::System => {
+            return Err(AudioError::Synthesis(
+                "system TTS does not use sherpa-onnx".to_string(),
+            ));
+        }
+    }
+
+    cmd.arg(text);
+    Ok(cmd)
+}
+
+fn sherpa_binary() -> String {
+    std::env::var("AXTERMINATOR_SHERPA_ONNX_TTS")
+        .unwrap_or_else(|_| "sherpa-onnx-offline-tts".to_string())
+}
+
+fn kokoro_speaker_id(voice: Option<&str>) -> Result<u16, AudioError> {
+    let Some(candidate) = voice.map(str::trim).filter(|v| !v.is_empty()) else {
+        return Ok(3);
+    };
+
+    if let Ok(id) = candidate.parse::<u16>()
+        && KOKORO_SPEAKERS
+            .iter()
+            .any(|(_, speaker_id)| *speaker_id == id)
+    {
+        return Ok(id);
+    }
+
+    KOKORO_SPEAKERS
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(candidate))
+        .map(|(_, id)| *id)
+        .ok_or_else(|| {
+            AudioError::Synthesis(format!(
+                "Unknown Kokoro voice \"{candidate}\". Use one of {} or a speaker id 0-52.",
+                KOKORO_SPEAKERS
+                    .iter()
+                    .map(|(name, _)| *name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spec_lookup_excludes_system_engine() {
+        assert!(spec_for_engine(TtsEngine::System).is_none());
+        assert_eq!(
+            spec_for_engine(TtsEngine::Kokoro).unwrap().directory,
+            "kokoro"
+        );
+        assert_eq!(
+            spec_for_engine(TtsEngine::Piper).unwrap().directory,
+            "piper"
+        );
+    }
+
+    #[test]
+    fn kokoro_voice_accepts_default_name_and_numeric_id() {
+        assert_eq!(kokoro_speaker_id(None).unwrap(), 3);
+        assert_eq!(kokoro_speaker_id(Some("af_heart")).unwrap(), 3);
+        assert_eq!(kokoro_speaker_id(Some("27")).unwrap(), 27);
+    }
+
+    #[test]
+    fn kokoro_voice_rejects_unknown_name() {
+        let err = kokoro_speaker_id(Some("does_not_exist")).unwrap_err();
+        assert_eq!(err.code(), "synthesis_error");
+    }
+}

--- a/src/bin/axterminator.rs
+++ b/src/bin/axterminator.rs
@@ -11,6 +11,7 @@
 //! axterminator tree         [--app <name>] [--depth <n>]
 //! axterminator apps
 //! axterminator check
+//! axterminator models tts list|download <engine>
 //! axterminator completions <shell>
 //! ```
 
@@ -142,6 +143,13 @@ enum Commands {
     /// Check accessibility permissions and system status.
     Check,
 
+    /// Manage optional model files.
+    #[cfg(feature = "enhanced-tts")]
+    Models {
+        #[command(subcommand)]
+        subcommand: ModelsSubcommand,
+    },
+
     /// Generate shell completion scripts.
     Completions {
         /// Target shell
@@ -242,6 +250,33 @@ enum McpSubcommand {
     },
 }
 
+#[cfg(feature = "enhanced-tts")]
+#[derive(Subcommand, Debug)]
+enum ModelsSubcommand {
+    /// Manage optional text-to-speech model bundles.
+    Tts {
+        #[command(subcommand)]
+        subcommand: TtsModelsSubcommand,
+    },
+}
+
+#[cfg(feature = "enhanced-tts")]
+#[derive(Subcommand, Debug)]
+enum TtsModelsSubcommand {
+    /// List enhanced TTS model installation status.
+    List,
+    /// Download and extract one enhanced TTS model bundle.
+    Download {
+        /// Engine model to download.
+        #[arg(value_parser = ["kokoro", "piper"])]
+        engine: String,
+
+        /// Replace any existing model directory.
+        #[arg(long)]
+        force: bool,
+    },
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -298,6 +333,8 @@ fn dispatch(cmd: Commands) -> Result<()> {
         } => cmd_tree(app.as_deref(), bundle_id.as_deref(), depth),
         Commands::Apps => cmd_apps(),
         Commands::Check => cmd_check(),
+        #[cfg(feature = "enhanced-tts")]
+        Commands::Models { subcommand } => dispatch_models(subcommand),
         Commands::Completions { shell } => cmd_completions(&shell),
         Commands::Upgrade { dry_run, quiet } => cmd_upgrade(dry_run, quiet),
     }
@@ -321,6 +358,21 @@ fn dispatch_mcp(sub: McpSubcommand) -> Result<()> {
             bind,
             localhost_only,
         } => dispatch_mcp_serve(http, stdio, token, &bind, localhost_only),
+    }
+}
+
+#[cfg(feature = "enhanced-tts")]
+fn dispatch_models(sub: ModelsSubcommand) -> Result<()> {
+    match sub {
+        ModelsSubcommand::Tts { subcommand } => dispatch_tts_models(subcommand),
+    }
+}
+
+#[cfg(feature = "enhanced-tts")]
+fn dispatch_tts_models(sub: TtsModelsSubcommand) -> Result<()> {
+    match sub {
+        TtsModelsSubcommand::List => cmd_models_tts_list(),
+        TtsModelsSubcommand::Download { engine, force } => cmd_models_tts_download(&engine, force),
     }
 }
 
@@ -933,6 +985,64 @@ fn cmd_check() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "enhanced-tts")]
+fn cmd_models_tts_list() -> Result<()> {
+    use axterminator::audio::tts_models::model_statuses;
+
+    let statuses = model_statuses().map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("Enhanced TTS models:");
+    for status in statuses {
+        let installed = if status.installed {
+            "installed"
+        } else {
+            "missing"
+        };
+        println!(
+            "- {:<6} {:<10} {}",
+            status.spec.engine.as_str(),
+            installed,
+            status.spec.display_name
+        );
+        println!("  path: {}", status.path.display());
+        println!("  source: {}", status.spec.archive_url);
+        println!("  docs: {}", status.spec.docs_url);
+        println!("  runtime: {}", status.spec.runtime_binary);
+        println!("  note: {}", status.spec.description);
+        if !status.missing_files.is_empty() {
+            println!("  missing: {}", status.missing_files.join(", "));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "enhanced-tts")]
+fn cmd_models_tts_download(engine: &str, force: bool) -> Result<()> {
+    use axterminator::audio::{TtsEngine, tts_models::download_model};
+
+    let engine = TtsEngine::parse_str(engine)
+        .filter(|engine| *engine != TtsEngine::System)
+        .ok_or_else(|| anyhow::anyhow!("engine must be \"kokoro\" or \"piper\""))?;
+    let result = download_model(engine, force).map_err(|e| anyhow::anyhow!("{e}"))?;
+    if result.downloaded {
+        println!(
+            "Downloaded {} to {}",
+            result.spec.display_name,
+            result.path.display()
+        );
+    } else {
+        println!(
+            "{} already installed at {}",
+            result.spec.display_name,
+            result.path.display()
+        );
+    }
+    println!(
+        "Use with: ax_speak {{\"text\":\"hello\", \"engine\":\"{}\"}}",
+        result.spec.engine.as_str()
+    );
+    Ok(())
+}
+
 fn cmd_completions(shell: &str) -> Result<()> {
     use clap_complete::Shell;
 
@@ -1196,6 +1306,44 @@ mod tests {
     fn parses_check_subcommand() {
         let cli = parse(&["check"]).unwrap();
         assert!(matches!(cli.command, Commands::Check));
+    }
+
+    #[cfg(feature = "enhanced-tts")]
+    #[test]
+    fn parses_models_tts_list() {
+        let cli = parse(&["models", "tts", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Models {
+                subcommand: ModelsSubcommand::Tts {
+                    subcommand: TtsModelsSubcommand::List
+                }
+            }
+        ));
+    }
+
+    #[cfg(feature = "enhanced-tts")]
+    #[test]
+    fn parses_models_tts_download_kokoro() {
+        let cli = parse(&["models", "tts", "download", "kokoro", "--force"]).unwrap();
+        match cli.command {
+            Commands::Models {
+                subcommand:
+                    ModelsSubcommand::Tts {
+                        subcommand: TtsModelsSubcommand::Download { engine, force },
+                    },
+            } => {
+                assert_eq!(engine, "kokoro");
+                assert!(force);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[cfg(feature = "enhanced-tts")]
+    #[test]
+    fn models_tts_download_rejects_unknown_engine() {
+        assert!(parse(&["models", "tts", "download", "festival"]).is_err());
     }
 
     #[test]

--- a/src/mcp/tools_audio.rs
+++ b/src/mcp/tools_audio.rs
@@ -159,9 +159,22 @@ fn tool_ax_speak() -> Tool {
         name: "ax_speak",
         title: "Synthesize and play text as speech",
         description: "Speak `text` through the default system audio output using \
-            NSSpeechSynthesizer (on-device, no network). Pass `voice` to select a \
-            specific installed macOS voice identifier from `ax_audio_voices`. \
+            the selected local TTS engine. The default `system` engine preserves \
+            the existing NSSpeechSynthesizer path (on-device, no network). Pass \
+            `voice` to select a specific installed macOS voice identifier from \
+            `ax_audio_voices` for `system`, or an engine-specific speaker ID/name \
+            for enhanced engines. \
             Blocks until synthesis completes and returns the elapsed duration.\n\
+            \n\
+            Engines:\n\
+            - `\"system\"` — default, Apple NSSpeechSynthesizer.\n\
+            - `\"kokoro\"` — optional Kokoro 82M model. Requires `enhanced-tts` \
+              and `axterminator models tts download kokoro`.\n\
+            - `\"piper\"` — optional Piper model. Requires `enhanced-tts` and \
+              `axterminator models tts download piper`.\n\
+            \n\
+            If an enhanced engine is requested but its model files are missing, \
+            the tool falls back to `system` and reports `fallback_reason`.\n\
             \n\
             Useful for: testing VoiceOver integrations, verifying audio feedback, \
             injecting voice prompts into the agent workflow.\n\
@@ -180,7 +193,16 @@ fn tool_ax_speak() -> Tool {
                 "voice": {
                     "type": "string",
                     "description": "Optional macOS speech voice identifier from `ax_audio_voices`. \
-                        When omitted, the current system default voice is used."
+                        For enhanced engines this may be a model speaker name or numeric \
+                        speaker ID. When omitted, the engine default voice is used."
+                },
+                "engine": {
+                    "type": "string",
+                    "enum": ["system", "kokoro", "piper"],
+                    "description": "TTS engine (default \"system\"). Enhanced engines require \
+                        the `enhanced-tts` feature and local model files; if files are absent \
+                        synthesis falls back to system TTS.",
+                    "default": "system"
                 }
             },
             "required": ["text"],
@@ -191,9 +213,12 @@ fn tool_ax_speak() -> Tool {
             "properties": {
                 "spoken":      { "type": "boolean" },
                 "duration_ms": { "type": "integer" },
-                "voice_used":  { "type": "string" }
+                "voice_used":  { "type": "string" },
+                "engine_requested": { "type": "string" },
+                "engine_used": { "type": "string" },
+                "fallback_reason": { "type": "string" }
             },
-            "required": ["spoken", "duration_ms", "voice_used"]
+            "required": ["spoken", "duration_ms", "voice_used", "engine_requested", "engine_used"]
         }),
         annotations: annotations::ACTION,
     }
@@ -375,6 +400,19 @@ pub(crate) fn handle_ax_speak(args: &Value) -> ToolCallResult {
     let Some(text) = args["text"].as_str().map(str::to_string) else {
         return ToolCallResult::error("Missing required field: text");
     };
+    let engine_str = args["engine"].as_str().unwrap_or("system");
+    let engine = match crate::audio::TtsEngine::parse_str(engine_str) {
+        Some(e) => e,
+        None => {
+            return ToolCallResult::error(
+                json!({
+                    "error": format!("Unknown TTS engine \"{engine_str}\". Valid values: \"system\", \"kokoro\", \"piper\"."),
+                    "error_code": "invalid_engine"
+                })
+                .to_string(),
+            );
+        }
+    };
     let voice = match args["voice"].as_str() {
         Some(candidate) if candidate.trim().is_empty() => {
             return ToolCallResult::error(
@@ -389,15 +427,20 @@ pub(crate) fn handle_ax_speak(args: &Value) -> ToolCallResult {
         None => None,
     };
 
-    match crate::audio::speak_with_voice(&text, voice.as_deref()) {
-        Ok(elapsed) => ToolCallResult::ok(
-            json!({
-                "spoken":      true,
-                "duration_ms": elapsed.as_millis() as u64,
-                "voice_used":  voice.unwrap_or_else(|| "system-default".to_string()),
-            })
-            .to_string(),
-        ),
+    match crate::audio::speak_with_engine(&text, voice.as_deref(), engine) {
+        Ok(result) => {
+            let mut payload = json!({
+                "spoken":           true,
+                "duration_ms":      result.elapsed.as_millis() as u64,
+                "voice_used":       result.voice_used,
+                "engine_requested": result.requested_engine.as_str(),
+                "engine_used":      result.engine_used.as_str(),
+            });
+            if let Some(reason) = result.fallback_reason {
+                payload["fallback_reason"] = Value::String(reason);
+            }
+            ToolCallResult::ok(payload.to_string())
+        }
         Err(e) => ToolCallResult::error(
             json!({ "error": e.to_string(), "error_code": e.code() }).to_string(),
         ),
@@ -499,6 +542,19 @@ mod tests {
     }
 
     #[test]
+    fn ax_speak_tool_includes_optional_engine_field() {
+        let tool = tool_ax_speak();
+        assert!(
+            tool.input_schema["properties"]["engine"].is_object(),
+            "engine property missing from schema"
+        );
+        assert_eq!(
+            tool.input_schema["properties"]["engine"]["enum"],
+            json!(["system", "kokoro", "piper"])
+        );
+    }
+
+    #[test]
     fn ax_audio_voices_tool_has_empty_input_schema() {
         let tool = tool_ax_audio_voices();
         assert!(
@@ -553,6 +609,15 @@ mod tests {
         assert!(result.is_error);
         let v: serde_json::Value = serde_json::from_str(&result.content[0].text).unwrap();
         assert_eq!(v["error_code"], "invalid_voice");
+    }
+
+    #[test]
+    fn handle_ax_speak_invalid_engine_returns_error_before_synthesis() {
+        let args = json!({ "text": "hello", "engine": "festival" });
+        let result = handle_ax_speak(&args);
+        assert!(result.is_error);
+        let v: serde_json::Value = serde_json::from_str(&result.content[0].text).unwrap();
+        assert_eq!(v["error_code"], "invalid_engine");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `TtsEngine` routing for `ax_speak` with `system`, `kokoro`, and `piper` engine names while preserving the existing system default path.
- Add optional `enhanced-tts` model registry and `axterminator models tts list/download` CLI for Kokoro/Piper model bundles under `~/.axterminator/models/tts/`.
- Return `engine_requested`, `engine_used`, and `fallback_reason` in MCP output, and update docs for the new feature flag and CLI flow.

## Validation
- `cargo fmt --all --check`
- `cargo check`
- `cargo check --features enhanced-tts`
- `cargo check --features "cli,audio,enhanced-tts,camera,spaces"`
- `cargo test --features audio ax_speak_tool -- --nocapture`
- `cargo test --features audio handle_ax_speak -- --nocapture`
- `cargo test --features enhanced-tts tts_engine -- --nocapture`
- `cargo test --features enhanced-tts tts_models -- --nocapture`
- `cargo test --features enhanced-tts models_tts -- --nocapture`
- `cargo run --features enhanced-tts -- models tts list`
- `cargo audit`
- `git diff --check`
- Verified model archive URLs with `curl -I --fail --location`.

## Notes
- Full `cargo clippy --features enhanced-tts --all-targets -- -D warnings` is currently blocked by pre-existing `collapsible_if` / `unnecessary_cast` warnings in untouched files. A scoped pass allowing those existing lint families passed: `cargo clippy --features enhanced-tts --all-targets -- -D warnings -A clippy::collapsible-if -A clippy::unnecessary-cast`.
- Model downloads were not executed in validation because the Kokoro archive is about 333 MB and Piper is about 64 MB; header checks verified the configured assets are reachable.
- Enhanced synthesis requires `sherpa-onnx-offline-tts` to be installed or `AXTERMINATOR_SHERPA_ONNX_TTS` to point at that binary.

Refs #30
