### PR TITLE
docs: decide AX-first vision fallback ADR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The boundary is macOS-only. iOS/iPadOS support is tracked but will be screenshot
 | Decision | Rationale | Do not |
 |---|---|---|
 | **macOS-only for AX-first path** | AX API is the entire performance + reliability story | Introduce Linux/Windows AX support that is not a thin shim |
-| **AX-first with vision fallback** (not vision-first) | AX is faster, more reliable, semantic; vision is the escape hatch | Make vision the default pipeline |
+| **AX-first with vision fallback** (not vision-first) | AX is faster, more reliable, semantic; vision is the escape hatch; see [ADR-0001](docs/architecture/decisions/ADR-0001-ax-first-with-vision-fallback.md) | Make vision the default pipeline |
 | **Background interaction** (no mouse-takeover required) | Parallel agent work; user keeps using their machine | Require focus-stealing; avoid mouse-driven automation |
 | **Accessibility permissions required for terminal/host** | macOS security model; no workaround | Add code paths that work around Privacy & Security panel |
 | **No on-device prereqs for iOS path** | Keeps "mac-only agent" contract intact | Require iOS UIAutomation test runner install |
@@ -67,6 +67,7 @@ The boundary is macOS-only. iOS/iPadOS support is tracked but will be screenshot
 | Self-healing locators | `src/healing.rs` + `src/healing_match.rs` |
 | Scene graph / UI patterns | `src/intent.rs` + `src/intent_matching.rs` |
 | Benchmarks | `benches/` |
+| AX-first vs vision-first decision | `docs/architecture/decisions/ADR-0001-ax-first-with-vision-fallback.md` |
 | Known limitations | README §Known Limitations + #43 (iOS) + #42 (AX-first rationale) |
 
 ## Build & Test

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ You probably use *both*. Those agents call axterminator as an MCP tool. axtermin
 
 It works everywhere vision works: foreground, focused, slow, expensive. axterminator works in the background, costs nothing, and is sub-millisecond. For automation of native macOS apps — the majority of business software — AX is strictly better. Vision is the escape hatch, not the default.
 
+The binding architecture decision is [ADR-0001: AX-first With Vision Fallback](docs/architecture/decisions/ADR-0001-ax-first-with-vision-fallback.md).
+
 **What app surfaces does axterminator cover?**
 
 Any macOS app that exposes the Accessibility API: all native AppKit/SwiftUI apps, Electron apps, web apps in Chrome/Safari/Firefox, terminal apps. Canvas-only surfaces (Figma canvas, game renderers, video players) use `ax_find_visual` — the built-in vision fallback that tries AX first and falls back to VLM automatically.

--- a/docs/architecture/decisions/ADR-0001-ax-first-with-vision-fallback.md
+++ b/docs/architecture/decisions/ADR-0001-ax-first-with-vision-fallback.md
@@ -1,0 +1,100 @@
+# ADR-0001: AX-first With Vision Fallback
+
+Status: Accepted
+Date: 2026-05-12
+Tracking: MIK-3305, MIK-3285, MIK-3286
+
+## Decision
+
+AXTerminator remains AX-first with vision fallback. The default execution path
+is the macOS Accessibility tree, self-healing locators, and semantic MCP/CLI
+actions. Vision and multimodal GUI models are allowed as perception, planning,
+ranking, and fallback layers, but they do not become the default actuator for
+macOS GUI work.
+
+This ADR supersedes any interpretation of MIK-3285 or MIK-3286 that would make
+screenshot-to-action or vision-first control the default macOS path. It does
+not supersede multimodal research. Model output may still propose intents,
+targets, candidates, and plans, but AXTerminator should normalize those outputs
+to semantic AX actions and verify them with AX assertions or screenshot/tree
+deltas where possible.
+
+## Source Evidence
+
+`CLAUDE.md` currently defines the product direction:
+
+> AX-first with vision-fallback means most interactions use the accessibility tree (fast, reliable, semantic), falling back to screenshot+vision only when AX is not available.
+
+The locked decision table is stricter:
+
+> AX-first with vision fallback (not vision-first)
+
+The same table explicitly rejects:
+
+> Make vision the default pipeline
+
+`README.md` mirrors that public positioning: AXTerminator uses the AX semantic
+tree as the opposite default to screenshot-to-pixel computer-use agents, with
+vision reserved for canvas apps, games, and renderer surfaces that AX cannot
+reach.
+
+MIK-3285 asks for GLM-5V-Turbo and AutoClaw research, including which vision
+capabilities are composable with AXTerminator's AX tree input. That is a
+multimodal compatibility question, not a binding default-pipeline decision.
+
+MIK-3286 is closer to the conflict. It frames CogAgent as multimodal GUI
+understanding, names a screenshot-to-action pipeline in its acceptance
+criteria, and the local SUPERCHARGE memo says UI-TARS-style desktop
+computer-use actions map into AXTerminator primitives. The binding
+interpretation is: screenshot-to-action models may feed the planner, but
+AXTerminator remains the semantic execution and verification layer.
+
+## Decision Matrix
+
+| Dimension | AX-first default | Vision-first default | Decision |
+| --- | --- | --- | --- |
+| Latency | Sub-millisecond element access is already the product claim and benchmark target. | Every action pays screenshot capture, model inference, and coordinate dispatch latency. | AX-first wins for macOS automation. |
+| Reliability | Semantic roles, labels, identifiers, and self-healing locators survive theme, font, and layout changes. | Pixel coordinates are brittle under visual drift, scaling, occlusion, and foreground-window changes. | AX-first wins for native and labeled UIs. |
+| Maintenance cost | One semantic action contract (`ax_find`, `ax_click`, `ax_type`, `ax_assert`) serves CLI, MCP, tests, and model adapters. | Each model family needs prompt/action parsing, coordinate normalization, error recovery, and drift-specific verification. | AX-first wins as the stable core. |
+| Capability ceiling | Cannot directly understand pure canvas, games, video, or non-AX-rendered regions without fallback. | Can inspect arbitrary screenshots and reason about visual-only surfaces. | Hybrid wins: AX-first with measured vision fallback. |
+
+## Binding Rules
+
+1. Default routing order is AX semantic lookup, self-healing locator recovery,
+   app/web semantic fallback if available, then vision fallback.
+2. A model may emit an intent, target descriptor, candidate element, or action
+   proposal. AXTerminator must prefer converting that proposal into semantic
+   AX actions before using raw coordinates.
+3. Raw pixel actions are allowed only when AX is unavailable, low-confidence,
+   or intentionally out of scope for the target surface.
+4. Vision fallback work must preserve the AX coverage gate already documented
+   in `README.md`: invest in vision defaults only when measured AX resolution
+   on the target surface is below the documented threshold.
+5. Any future change to vision-first defaults requires a superseding ADR with
+   AX coverage data, latency data, reliability results, and a migration plan.
+6. MIK-3285, MIK-3286, and follow-on multimodal issues must link this ADR and
+   treat vision/model output as planner input unless they explicitly propose a
+   superseding ADR.
+
+## Consequences
+
+AXTerminator's competitive moat stays coherent: background-safe, semantic,
+cheap, and fast interaction on macOS. Multimodal work is still valuable because
+it can expand coverage for canvas-like surfaces, improve candidate ranking, and
+make cross-platform research practical. The cost is that model adapters must
+translate into AXTerminator's action vocabulary instead of directly owning the
+main control loop.
+
+## Validation
+
+- MIK-3305.ADR.1: `CLAUDE.md` AX-first wording read and quoted above.
+- MIK-3305.ADR.2: MIK-3285 and MIK-3286 claims summarized above.
+- MIK-3305.ADR.3: latency, reliability, maintenance cost, and capability
+  ceiling evaluated in the decision matrix.
+- MIK-3305.ADR.4: binding decision and explicit vision-first supersession are
+  recorded in this ADR.
+- MIK-3305.ADR.5: Hebb decision memory recorded as
+  `memory:2qnn0x5qhyz856oiq1ii`; contradiction check returned no
+  conflicting decisions.
+- MIK-3305.ADR.6: `CLAUDE.md` and the MIK-3286 SUPERCHARGE memo link this ADR;
+  MIK-3285/MIK-3286 Linear updates should link the merged PR or main-branch ADR.

--- a/docs/portfolio/supercharge/cogagent-stack-2026.md
+++ b/docs/portfolio/supercharge/cogagent-stack-2026.md
@@ -6,6 +6,8 @@ Evidence date: 2026-05-08
 
 Select UI-TARS-2 as the first model target for the sovereign multimodal GUI-agent stack. Keep CogAgent-9B-20241220 as a comparison baseline and possible fallback evaluator.
 
+ADR alignment: [ADR-0001: AX-first With Vision Fallback](../../architecture/decisions/ADR-0001-ax-first-with-vision-fallback.md) is binding for AXTerminator. UI-TARS-style screenshot-to-action output is planner input; AXTerminator remains the semantic AX-first execution and verification layer unless a future superseding ADR proves a measured vision-first default should replace it.
+
 The decisive factor is integration fit, not raw model appeal. UI-TARS-2 and the UI-TARS Desktop stack already express desktop GUI work as screenshot-to-action computer-use loops, and that maps directly into axterminator primitives such as `ax_find`, `ax_click`, `ax_type`, `ax_scroll`, `ax_key_press`, and `ax_assert`. CogAgent is credible GUI-agent research, but its current published path has heavier local inference requirements and a separate model-weight license constraint.
 
 ## Acceptance Criteria
@@ -54,6 +56,7 @@ Live execution status: blocked. `axterminator check` returned `Accessibility: DI
 ## Next Implementation Slice
 
 - Add a provider-neutral action adapter that converts UI-TARS-style computer-use actions into axterminator durable steps.
+- Keep the adapter AX-first per ADR-0001: model actions should be normalized into semantic AXTerminator primitives before falling back to raw coordinates.
 - Add a trace format that stores screenshot hash, AX tree hash, hebb memory keys, planned action, executed action, and verification result.
 - Re-run the three demo tasks live after Accessibility is enabled. File the consumer-product positioning ticket only if autonomous live success exceeds 70%.
 


### PR DESCRIPTION
## Summary
- add ADR-0001 accepting AX-first with vision fallback as the binding macOS default
- explicitly supersede vision-first/default-actuator interpretations of MIK-3285 and MIK-3286
- link the ADR from CLAUDE.md, README, and the MIK-3286 SUPERCHARGE memo

## Linear
- MIK-3305

## KPI Impact
- Developer/operator impact: removes a 20x architectural ambiguity from future axterminator multimodal work. Future model adapters have one routing rule: model output can plan/rank/propose, but AXTerminator remains the semantic execution and verification layer by default.

## DoR Evidence
- ACs: MIK-3305 has six testable ADR acceptance criteria.
- Scope/targets: docs-only ADR and source links in CLAUDE.md, README.md, and docs/portfolio/supercharge/cogagent-stack-2026.md.
- ROI/value: issue declares ROI 20x by removing implementation thrash.
- Duplicate check: `rg` found existing AX-first sections but no binding ADR file.
- Risks: over-constraining multimodal research; stale references in dependent tickets. Mitigation: ADR permits fallback/planner roles and requires future superseding ADR for measured default changes.

## DoD Evidence
- AC1: CLAUDE.md AX-first wording read and quoted in ADR-0001.
- AC2: MIK-3285/MIK-3286 claims summarized with the actual conflict nuance.
- AC3: decision matrix covers latency, reliability, maintenance cost, and capability ceiling.
- AC4: binding decision records AX-first default and supersedes vision-first default interpretations.
- AC5: Hebb `decide` memory recorded as `memory:2qnn0x5qhyz856oiq1ii`; no contradictory decisions returned. Local Hebb CLI store is corrupt, but the running MCP server path succeeded.
- AC6: CLAUDE.md and MIK-3286 memo link the ADR; Linear MIK-3285/MIK-3286 comments will be linked after PR creation.

## Validation
- `git diff --cached --check`
- `cargo fmt --all --check`
- `cargo check`
- `cargo audit`
- secret scan on changed files: only pre-existing README example token hit; no added secret-like lines

## Residual Risk / N/A
- Docs-only change: no runtime tests, perf benchmark, rollout, feature flag, telemetry, or mutation testing required.
- Local `hebb remember --decision` CLI failed due existing RocksDB corruption in `~/.local/share/hebb/db`; MCP `decide` over the running Hebb server was used as the evidence-backed path.
