### PR TITLE
chore: satisfy strict clippy

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -181,10 +181,10 @@ impl AXApp {
             query: query.to_string(),
         };
 
-        if let Some(cached) = crate::cache::global_cache().get(&cache_key) {
-            if cached.exists() {
-                return Ok(cached);
-            }
+        if let Some(cached) = crate::cache::global_cache().get(&cache_key)
+            && cached.exists()
+        {
+            return Ok(cached);
         }
 
         // Perform breadth-first search of accessibility tree

--- a/src/blackbox.rs
+++ b/src/blackbox.rs
@@ -492,10 +492,10 @@ fn find_text_in_tree(root: crate::accessibility::AXUIElementRef, query: &str) ->
             attributes::AX_VALUE,
             attributes::AX_LABEL,
         ] {
-            if let Some(text) = accessibility::get_string_attribute_value(elem, attr) {
-                if text.to_lowercase().contains(&query_lower) {
-                    return Some(text);
-                }
+            if let Some(text) = accessibility::get_string_attribute_value(elem, attr)
+                && text.to_lowercase().contains(&query_lower)
+            {
+                return Some(text);
             }
         }
 

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -442,15 +442,14 @@ fn active_network_interfaces() -> Vec<NetworkInterface> {
         } else if line.contains("inet ") && !line.contains("inet6") && !current_name.is_empty() {
             // IPv4 line: "	inet 192.168.1.5 netmask ..."
             let parts: Vec<&str> = line.split_whitespace().collect();
-            if let Some(pos) = parts.iter().position(|&s| s == "inet") {
-                if let Some(&ip) = parts.get(pos + 1) {
-                    if ip != "127.0.0.1" {
-                        interfaces.push(NetworkInterface {
-                            name: current_name.clone(),
-                            ipv4: Some(ip.to_string()),
-                        });
-                    }
-                }
+            if let Some(pos) = parts.iter().position(|&s| s == "inet")
+                && let Some(&ip) = parts.get(pos + 1)
+                && ip != "127.0.0.1"
+            {
+                interfaces.push(NetworkInterface {
+                    name: current_name.clone(),
+                    ipv4: Some(ip.to_string()),
+                });
             }
         }
     }

--- a/src/copilot_extract.rs
+++ b/src/copilot_extract.rs
@@ -100,17 +100,17 @@ pub(crate) fn first_window_ref(
 fn find_active_tab(children: &[AXUIElementRef]) -> Option<String> {
     children.iter().find_map(|&c| {
         let role = get_string_attribute_value(c, attributes::AX_ROLE)?;
-        if role == "AXTabGroup" {
-            if let Ok(tab_children) = get_children(c) {
-                return tab_children.iter().find_map(|&tc| {
-                    let selected = get_bool_attribute_value(tc, "AXSelected")?;
-                    if selected {
-                        get_string_attribute_value(tc, attributes::AX_TITLE)
-                    } else {
-                        None
-                    }
-                });
-            }
+        if role == "AXTabGroup"
+            && let Ok(tab_children) = get_children(c)
+        {
+            return tab_children.iter().find_map(|&tc| {
+                let selected = get_bool_attribute_value(tc, "AXSelected")?;
+                if selected {
+                    get_string_attribute_value(tc, attributes::AX_TITLE)
+                } else {
+                    None
+                }
+            });
         }
         None
     })
@@ -140,17 +140,16 @@ fn find_selected_text_in(elements: &[AXUIElementRef]) -> Option<String> {
     for &el in elements {
         let role = get_string_attribute_value(el, attributes::AX_ROLE);
         let is_text = matches!(role.as_deref(), Some("AXTextField" | "AXTextArea"));
-        if is_text {
-            if let Some(text) = get_string_attribute_value(el, "AXSelectedText") {
-                if !text.is_empty() {
-                    return Some(crate::copilot_state::truncate_str(text, 512));
-                }
-            }
+        if is_text
+            && let Some(text) = get_string_attribute_value(el, "AXSelectedText")
+            && !text.is_empty()
+        {
+            return Some(crate::copilot_state::truncate_str(text, 512));
         }
-        if let Ok(kids) = get_children(el) {
-            if let Some(found) = find_selected_text_in(&kids) {
-                return Some(found);
-            }
+        if let Ok(kids) = get_children(el)
+            && let Some(found) = find_selected_text_in(&kids)
+        {
+            return Some(found);
         }
     }
     None
@@ -163,19 +162,19 @@ fn find_selected_list_row(win: AXUIElementRef, _children: &[AXUIElementRef]) -> 
 
 fn find_list_row_in(elements: &[AXUIElementRef]) -> Option<usize> {
     for &el in elements {
-        if get_string_attribute_value(el, attributes::AX_ROLE).as_deref() == Some("AXList") {
-            if let Ok(rows) = get_children(el) {
-                for (i, &row) in rows.iter().enumerate() {
-                    if get_bool_attribute_value(row, "AXSelected").unwrap_or(false) {
-                        return Some(i);
-                    }
+        if get_string_attribute_value(el, attributes::AX_ROLE).as_deref() == Some("AXList")
+            && let Ok(rows) = get_children(el)
+        {
+            for (i, &row) in rows.iter().enumerate() {
+                if get_bool_attribute_value(row, "AXSelected").unwrap_or(false) {
+                    return Some(i);
                 }
             }
         }
-        if let Ok(kids) = get_children(el) {
-            if let Some(idx) = find_list_row_in(&kids) {
-                return Some(idx);
-            }
+        if let Ok(kids) = get_children(el)
+            && let Some(idx) = find_list_row_in(&kids)
+        {
+            return Some(idx);
         }
     }
     None
@@ -191,12 +190,11 @@ fn collect_selected_items(win: AXUIElementRef) -> Vec<String> {
 fn collect_selected_items_in(elements: &[AXUIElementRef]) -> Vec<String> {
     let mut result = Vec::new();
     for &el in elements {
-        if get_bool_attribute_value(el, "AXSelected").unwrap_or(false) {
-            if let Some(title) = get_string_attribute_value(el, attributes::AX_TITLE)
+        if get_bool_attribute_value(el, "AXSelected").unwrap_or(false)
+            && let Some(title) = get_string_attribute_value(el, attributes::AX_TITLE)
                 .or_else(|| get_string_attribute_value(el, attributes::AX_VALUE))
-            {
-                result.push(title);
-            }
+        {
+            result.push(title);
         }
         if let Ok(kids) = get_children(el) {
             result.extend(collect_selected_items_in(&kids));
@@ -233,19 +231,19 @@ fn find_sidebar_selection(
 
 fn find_role_selection_in(elements: &[AXUIElementRef], target_role: &str) -> Option<String> {
     for &el in elements {
-        if get_string_attribute_value(el, attributes::AX_ROLE).as_deref() == Some(target_role) {
-            if let Ok(rows) = get_children(el) {
-                for &row in &rows {
-                    if get_bool_attribute_value(row, "AXSelected").unwrap_or(false) {
-                        return get_string_attribute_value(row, attributes::AX_TITLE);
-                    }
+        if get_string_attribute_value(el, attributes::AX_ROLE).as_deref() == Some(target_role)
+            && let Ok(rows) = get_children(el)
+        {
+            for &row in &rows {
+                if get_bool_attribute_value(row, "AXSelected").unwrap_or(false) {
+                    return get_string_attribute_value(row, attributes::AX_TITLE);
                 }
             }
         }
-        if let Ok(kids) = get_children(el) {
-            if let Some(found) = find_role_selection_in(&kids, target_role) {
-                return Some(found);
-            }
+        if let Ok(kids) = get_children(el)
+            && let Some(found) = find_role_selection_in(&kids, target_role)
+        {
+            return Some(found);
         }
     }
     None
@@ -291,16 +289,14 @@ fn collect_text_in(elements: &[AXUIElementRef], budget: usize) -> String {
         if matches!(
             role.as_deref(),
             Some("AXStaticText" | "AXTextField" | "AXTextArea")
-        ) {
-            if let Some(val) = get_string_attribute_value(el, attributes::AX_VALUE)
-                .or_else(|| get_string_attribute_value(el, attributes::AX_TITLE))
-            {
-                if !buf.is_empty() {
-                    buf.push(' ');
-                }
-                let remaining = budget.saturating_sub(buf.len());
-                buf.push_str(&crate::copilot_state::truncate_str(val, remaining));
+        ) && let Some(val) = get_string_attribute_value(el, attributes::AX_VALUE)
+            .or_else(|| get_string_attribute_value(el, attributes::AX_TITLE))
+        {
+            if !buf.is_empty() {
+                buf.push(' ');
             }
+            let remaining = budget.saturating_sub(buf.len());
+            buf.push_str(&crate::copilot_state::truncate_str(val, remaining));
         }
         if let Ok(kids) = get_children(el) {
             let sub = collect_text_in(&kids, budget.saturating_sub(buf.len()));

--- a/src/cross_app.rs
+++ b/src/cross_app.rs
@@ -172,10 +172,9 @@ impl CrossAppTracker {
             .then_some(())
             .map(|_| None)
             .unwrap_or(Some(from_app.clone()))
+            && let Some(state) = self.apps.get_mut(prev)
         {
-            if let Some(state) = self.apps.get_mut(prev) {
-                state.focused = false;
-            }
+            state.focused = false;
         }
 
         // Ensure destination app entry exists
@@ -330,11 +329,11 @@ impl CrossAppTracker {
 
     /// Credit elapsed dwell time to the current app.
     fn flush_dwell_time(&mut self, now_ms: u64) {
-        if let Some(app) = &self.current_app.clone() {
-            if let Some(state) = self.apps.get_mut(app) {
-                let elapsed = now_ms.saturating_sub(self.current_focus_start_ms);
-                state.total_time_ms = state.total_time_ms.saturating_add(elapsed);
-            }
+        if let Some(app) = &self.current_app.clone()
+            && let Some(state) = self.apps.get_mut(app)
+        {
+            let elapsed = now_ms.saturating_sub(self.current_focus_start_ms);
+            state.total_time_ms = state.total_time_ms.saturating_add(elapsed);
         }
     }
 

--- a/src/element.rs
+++ b/src/element.rs
@@ -271,11 +271,10 @@ impl AXElement {
         let (key_code, needs_shift) = char_to_keycode(ch);
 
         // Press shift if needed
-        if needs_shift {
-            if let Ok(shift_down) = CGEvent::new_keyboard_event(source.clone(), 56, true) {
-                shift_down.post_to_pid(pid);
-                std::thread::sleep(Duration::from_millis(10));
-            }
+        if needs_shift && let Ok(shift_down) = CGEvent::new_keyboard_event(source.clone(), 56, true)
+        {
+            shift_down.post_to_pid(pid);
+            std::thread::sleep(Duration::from_millis(10));
         }
 
         // Key down
@@ -294,11 +293,10 @@ impl AXElement {
         }
 
         // Release shift if needed
-        if needs_shift {
-            if let Ok(shift_up) = CGEvent::new_keyboard_event(source.clone(), 56, false) {
-                shift_up.post_to_pid(pid);
-                std::thread::sleep(Duration::from_millis(10));
-            }
+        if needs_shift && let Ok(shift_up) = CGEvent::new_keyboard_event(source.clone(), 56, false)
+        {
+            shift_up.post_to_pid(pid);
+            std::thread::sleep(Duration::from_millis(10));
         }
 
         Ok(())
@@ -329,10 +327,9 @@ impl AXElement {
         loop {
             if let Some(role) =
                 accessibility::get_string_attribute_value(current, attributes::AX_ROLE)
+                && role == "AXWindow"
             {
-                if role == "AXWindow" {
-                    return Ok(current);
-                }
+                return Ok(current);
             }
 
             // Get parent
@@ -427,17 +424,17 @@ impl AXElement {
     ) -> AXResult<AXElement> {
         for &element in elements {
             // Check if this element matches
-            if let Some(attr_value) = accessibility::get_string_attribute_value(element, attr) {
-                if attr_value.contains(value) {
-                    return Ok(AXElement::new(element));
-                }
+            if let Some(attr_value) = accessibility::get_string_attribute_value(element, attr)
+                && attr_value.contains(value)
+            {
+                return Ok(AXElement::new(element));
             }
 
             // Search in children
-            if let Ok(children) = accessibility::get_children(element) {
-                if let Ok(found) = self.search_in_elements(&children, attr, value) {
-                    return Ok(found);
-                }
+            if let Ok(children) = accessibility::get_children(element)
+                && let Ok(found) = self.search_in_elements(&children, attr, value)
+            {
+                return Ok(found);
             }
         }
 
@@ -468,10 +465,10 @@ impl AXElement {
                 return Ok(AXElement::new(element));
             }
 
-            if let Ok(children) = accessibility::get_children(element) {
-                if let Ok(found) = self.search_in_elements_any_text(&children, query) {
-                    return Ok(found);
-                }
+            if let Ok(children) = accessibility::get_children(element)
+                && let Ok(found) = self.search_in_elements_any_text(&children, query)
+            {
+                return Ok(found);
             }
         }
 
@@ -655,17 +652,16 @@ mod tests {
             .output()
             .expect("Failed to run pgrep");
 
-        if let Ok(pid_str) = String::from_utf8(output.stdout) {
-            if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                if let Ok(app_ref) = accessibility::create_application_element(pid) {
-                    let element = AXElement::new(app_ref);
+        if let Ok(pid_str) = String::from_utf8(output.stdout)
+            && let Ok(pid) = pid_str.trim().parse::<i32>()
+            && let Ok(app_ref) = accessibility::create_application_element(pid)
+        {
+            let element = AXElement::new(app_ref);
 
-                    // Finder should have a role
-                    let role = element.role();
-                    assert!(role.is_some());
-                    assert_eq!(role.unwrap(), "AXApplication");
-                }
-            }
+            // Finder should have a role
+            let role = element.role();
+            assert!(role.is_some());
+            assert_eq!(role.unwrap(), "AXApplication");
         }
     }
 
@@ -682,17 +678,16 @@ mod tests {
             .output()
             .expect("Failed to run pgrep");
 
-        if let Ok(pid_str) = String::from_utf8(output.stdout) {
-            if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                if let Ok(app_ref) = accessibility::create_application_element(pid) {
-                    let element = AXElement::new(app_ref);
+        if let Ok(pid_str) = String::from_utf8(output.stdout)
+            && let Ok(pid) = pid_str.trim().parse::<i32>()
+            && let Ok(app_ref) = accessibility::create_application_element(pid)
+        {
+            let element = AXElement::new(app_ref);
 
-                    // Check enabled attribute (should return a boolean)
-                    let enabled = element.enabled();
-                    // Value doesn't matter, just that it returns without panic
-                    let _ = enabled;
-                }
-            }
+            // Check enabled attribute (should return a boolean)
+            let enabled = element.enabled();
+            // Value doesn't matter, just that it returns without panic
+            let _ = enabled;
         }
     }
 
@@ -709,25 +704,24 @@ mod tests {
             .output()
             .expect("Failed to run pgrep");
 
-        if let Ok(pid_str) = String::from_utf8(output.stdout) {
-            if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                if let Ok(app_ref) = accessibility::create_application_element(pid) {
-                    let element = AXElement::new(app_ref);
+        if let Ok(pid_str) = String::from_utf8(output.stdout)
+            && let Ok(pid) = pid_str.trim().parse::<i32>()
+            && let Ok(app_ref) = accessibility::create_application_element(pid)
+        {
+            let element = AXElement::new(app_ref);
 
-                    // Try to get windows
-                    if let Ok(children) = accessibility::get_children(element.element) {
-                        for child in children.iter().take(5) {
-                            let child_elem = AXElement::new(*child);
-                            if let Some(role) = child_elem.role() {
-                                if role == "AXWindow" {
-                                    // Window should have bounds
-                                    if let Some((_x, _y, w, h)) = child_elem.bounds() {
-                                        assert!(w > 0.0);
-                                        assert!(h > 0.0);
-                                        return;
-                                    }
-                                }
-                            }
+            // Try to get windows
+            if let Ok(children) = accessibility::get_children(element.element) {
+                for child in children.iter().take(5) {
+                    let child_elem = AXElement::new(*child);
+                    if let Some(role) = child_elem.role()
+                        && role == "AXWindow"
+                    {
+                        // Window should have bounds
+                        if let Some((_x, _y, w, h)) = child_elem.bounds() {
+                            assert!(w > 0.0);
+                            assert!(h > 0.0);
+                            return;
                         }
                     }
                 }
@@ -748,13 +742,12 @@ mod tests {
             .output()
             .expect("Failed to run pgrep");
 
-        if let Ok(pid_str) = String::from_utf8(output.stdout) {
-            if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                if let Ok(app_ref) = accessibility::create_application_element(pid) {
-                    let element = AXElement::new(app_ref);
-                    assert!(element.exists());
-                }
-            }
+        if let Ok(pid_str) = String::from_utf8(output.stdout)
+            && let Ok(pid) = pid_str.trim().parse::<i32>()
+            && let Ok(app_ref) = accessibility::create_application_element(pid)
+        {
+            let element = AXElement::new(app_ref);
+            assert!(element.exists());
         }
     }
 

--- a/src/healing.rs
+++ b/src/healing.rs
@@ -144,16 +144,15 @@ pub fn find_with_healing(query: &ElementQuery, root: AXUIElementRef) -> AXResult
     let config = get_global_config();
 
     // Check cache first if enabled
-    if config.cache_healed {
-        if let Ok(cache) = HEALING_CACHE.read() {
-            if let Some(cached_query) = cache.get(&query.original) {
-                // Try the cached successful query first
-                for strategy_name in &config.strategies {
-                    let strategy = parse_strategy(strategy_name);
-                    if let Some(element) = try_strategy(strategy, cached_query, root) {
-                        return Ok(element);
-                    }
-                }
+    if config.cache_healed
+        && let Ok(cache) = HEALING_CACHE.read()
+        && let Some(cached_query) = cache.get(&query.original)
+    {
+        // Try the cached successful query first
+        for strategy_name in &config.strategies {
+            let strategy = parse_strategy(strategy_name);
+            if let Some(element) = try_strategy(strategy, cached_query, root) {
+                return Ok(element);
             }
         }
     }
@@ -170,10 +169,10 @@ pub fn find_with_healing(query: &ElementQuery, root: AXUIElementRef) -> AXResult
         let strategy = parse_strategy(strategy_name);
         if let Some(element) = try_strategy(strategy, query, root) {
             // Cache successful query if enabled
-            if config.cache_healed {
-                if let Ok(mut cache) = HEALING_CACHE.write() {
-                    cache.insert(query.original.clone(), query.clone());
-                }
+            if config.cache_healed
+                && let Ok(mut cache) = HEALING_CACHE.write()
+            {
+                cache.insert(query.original.clone(), query.clone());
             }
             return Ok(element);
         }
@@ -422,11 +421,11 @@ fn try_by_data_testid(query: &ElementQuery, root: AXUIElementRef) -> Option<AXEl
     walk_tree(
         root,
         &mut |element| {
-            if let Some(identifier) = get_string_attr(element, attributes::AX_IDENTIFIER) {
-                if identifier == *target_id {
-                    found = Some(element);
-                    return true;
-                }
+            if let Some(identifier) = get_string_attr(element, attributes::AX_IDENTIFIER)
+                && identifier == *target_id
+            {
+                found = Some(element);
+                return true;
             }
             false
         },
@@ -445,19 +444,19 @@ fn try_by_aria_label(query: &ElementQuery, root: AXUIElementRef) -> Option<AXEle
         root,
         &mut |element| {
             // Try AXLabel first
-            if let Some(label) = get_string_attr(element, attributes::AX_LABEL) {
-                if label == *target_label {
-                    found = Some(element);
-                    return true;
-                }
+            if let Some(label) = get_string_attr(element, attributes::AX_LABEL)
+                && label == *target_label
+            {
+                found = Some(element);
+                return true;
             }
 
             // Try AXDescription
-            if let Some(desc) = get_string_attr(element, attributes::AX_DESCRIPTION) {
-                if desc == *target_label {
-                    found = Some(element);
-                    return true;
-                }
+            if let Some(desc) = get_string_attr(element, attributes::AX_DESCRIPTION)
+                && desc == *target_label
+            {
+                found = Some(element);
+                return true;
             }
 
             false
@@ -476,11 +475,11 @@ fn try_by_identifier(query: &ElementQuery, root: AXUIElementRef) -> Option<AXEle
     walk_tree(
         root,
         &mut |element| {
-            if let Some(identifier) = get_string_attr(element, attributes::AX_IDENTIFIER) {
-                if identifier == *target_id {
-                    found = Some(element);
-                    return true;
-                }
+            if let Some(identifier) = get_string_attr(element, attributes::AX_IDENTIFIER)
+                && identifier == *target_id
+            {
+                found = Some(element);
+                return true;
             }
             false
         },
@@ -498,11 +497,11 @@ fn try_by_title(query: &ElementQuery, root: AXUIElementRef) -> Option<AXElement>
     walk_tree(
         root,
         &mut |element| {
-            if let Some(title) = get_string_attr(element, attributes::AX_TITLE) {
-                if fuzzy_match(&title, target_title, 0.8) {
-                    found = Some(element);
-                    return true;
-                }
+            if let Some(title) = get_string_attr(element, attributes::AX_TITLE)
+                && fuzzy_match(&title, target_title, 0.8)
+            {
+                found = Some(element);
+                return true;
             }
             false
         },
@@ -654,12 +653,11 @@ fn get_window_dimensions(root: AXUIElementRef) -> Option<(f64, f64)> {
     // Try to find a window parent
     let mut current = root;
     for _ in 0..10 {
-        if let Some(role) = get_string_attr(current, attributes::AX_ROLE) {
-            if role == "AXWindow" {
-                if let Some(size) = crate::accessibility::get_size_attribute(current) {
-                    return Some((size.width, size.height));
-                }
-            }
+        if let Some(role) = get_string_attr(current, attributes::AX_ROLE)
+            && role == "AXWindow"
+            && let Some(size) = crate::accessibility::get_size_attribute(current)
+        {
+            return Some((size.width, size.height));
         }
 
         // Get parent

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -217,10 +217,10 @@ pub fn scan_scene_bounded(root_element: AXUIElementRef, max_nodes: usize) -> AXR
         let node_id = graph.push(node);
 
         // Register this child with its parent
-        if let Some(pid) = queued.parent {
-            if let Some(parent) = graph.get_mut(pid) {
-                parent.children.push(node_id);
-            }
+        if let Some(pid) = queued.parent
+            && let Some(parent) = graph.get_mut(pid)
+        {
+            parent.children.push(node_id);
         }
 
         // Enqueue children. get_children() returns +1 retained refs; the queue

--- a/src/mcp/security.rs
+++ b/src/mcp/security.rs
@@ -366,11 +366,11 @@ impl AuditLog {
 
 /// Attempt to open the log file; returns `None` on failure (best-effort).
 fn try_open_log(path: &PathBuf) -> Option<BufWriter<std::fs::File>> {
-    if let Some(parent) = path.parent() {
-        if let Err(e) = fs::create_dir_all(parent) {
-            warn!(path = %parent.display(), error = %e, "audit log dir creation failed");
-            return None;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        warn!(path = %parent.display(), error = %e, "audit log dir creation failed");
+        return None;
     }
     match OpenOptions::new().create(true).append(true).open(path) {
         Ok(f) => Some(BufWriter::new(f)),

--- a/src/mcp/server_handlers.rs
+++ b/src/mcp/server_handlers.rs
@@ -523,12 +523,11 @@ impl Server {
 
         // Gate 3 — app policy (applies to ax_connect only; the app_id is
         // checked before we even attempt the AX connection).
-        if name == "ax_connect" {
-            if let Some(app_id) = args.get("app").and_then(Value::as_str) {
-                if let Err(msg) = self.security.check_app_allowed(app_id) {
-                    return crate::mcp::protocol::ToolCallResult::error(msg);
-                }
-            }
+        if name == "ax_connect"
+            && let Some(app_id) = args.get("app").and_then(Value::as_str)
+            && let Err(msg) = self.security.check_app_allowed(app_id)
+        {
+            return crate::mcp::protocol::ToolCallResult::error(msg);
         }
         if name == "ax_click_at" && !self.security.app_policy_is_permissive() {
             return crate::mcp::protocol::ToolCallResult::error(

--- a/src/mcp/tools_gui.rs
+++ b/src/mcp/tools_gui.rs
@@ -750,15 +750,15 @@ fn build_tree_node<W: Write>(
     }
 
     // Emit one progress notification the first time we enter each depth layer.
-    if let Some(d) = emitted.get_mut(current_depth) {
-        if !*d {
-            *d = true;
-            if let Some(rep) = reporter {
-                let layer = current_depth + 1;
-                let msg = format!("Scanning layer {layer}/{max_depth}…");
-                // Best-effort: silently ignore I/O errors in progress notifications.
-                let _ = rep.step(&msg);
-            }
+    if let Some(d) = emitted.get_mut(current_depth)
+        && !*d
+    {
+        *d = true;
+        if let Some(rep) = reporter {
+            let layer = current_depth + 1;
+            let msg = format!("Scanning layer {layer}/{max_depth}…");
+            // Best-effort: silently ignore I/O errors in progress notifications.
+            let _ = rep.step(&msg);
         }
     }
 

--- a/src/mcp/tools_handlers.rs
+++ b/src/mcp/tools_handlers.rs
@@ -132,21 +132,21 @@ fn semantic_find_fallback(app: &crate::app::AXApp, query: &str) -> ToolCallResul
     let fq = FindQuery::new(query);
     let result = finder.find(&scene, &fq);
 
-    if let Some(top) = result.matches.first() {
-        if top.score >= 0.3 {
-            return ToolCallResult::ok(
-                json!({
-                    "found": true,
-                    "semantic_match": true,
-                    "confidence": top.score,
-                    "role": top.role,
-                    "label": top.label,
-                    "bounds": top.bounds.map(|(x, y, w, h)| [x, y, w, h]),
-                    "reasoning": top.reasoning
-                })
-                .to_string(),
-            );
-        }
+    if let Some(top) = result.matches.first()
+        && top.score >= 0.3
+    {
+        return ToolCallResult::ok(
+            json!({
+                "found": true,
+                "semantic_match": true,
+                "confidence": top.score,
+                "role": top.role,
+                "label": top.label,
+                "bounds": top.bounds.map(|(x, y, w, h)| [x, y, w, h]),
+                "reasoning": top.reasoning
+            })
+            .to_string(),
+        );
     }
 
     ToolCallResult::error(format!("Element not found: '{query}'"))

--- a/src/mcp/tools_power.rs
+++ b/src/mcp/tools_power.rs
@@ -71,10 +71,10 @@ pub(crate) fn call_power_tool(name: &str, args: &Value, _mode: &str) -> ToolCall
 }
 
 fn resolve_path(raw: &str) -> String {
-    if let Some(rest) = raw.strip_prefix("~/") {
-        if let Ok(home) = std::env::var("HOME") {
-            return format!("{home}/{rest}");
-        }
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return format!("{home}/{rest}");
     }
     raw.to_string()
 }

--- a/src/mcp/tools_system.rs
+++ b/src/mcp/tools_system.rs
@@ -52,10 +52,10 @@ pub(crate) fn system_tools() -> Vec<Tool> {
 }
 
 fn resolve_path(raw: &str) -> String {
-    if let Some(rest) = raw.strip_prefix("~/") {
-        if let Ok(home) = std::env::var("HOME") {
-            return format!("{home}/{rest}");
-        }
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return format!("{home}/{rest}");
     }
     raw.to_string()
 }
@@ -130,10 +130,10 @@ pub(crate) fn call_system_tool(name: &str, args: &Value, _mode: &str) -> ToolCal
             let mut procs: Vec<Value> = Vec::new();
             for (pid, proc) in sys.processes() {
                 let name = proc.name().to_string_lossy().to_string();
-                if let Some(ref f) = filter {
-                    if !name.to_lowercase().contains(f) {
-                        continue;
-                    }
+                if let Some(ref f) = filter
+                    && !name.to_lowercase().contains(f)
+                {
+                    continue;
                 }
                 procs.push(json!({
                     "pid": pid.as_u32(),

--- a/src/mcp/tools_system_ext.rs
+++ b/src/mcp/tools_system_ext.rs
@@ -96,23 +96,23 @@ fn memory_pressure() -> String {
 
 fn handle_disk(args: &Value) -> ToolCallResult {
     let path = args.get("path").and_then(|v| v.as_str()).unwrap_or("/");
-    if let Ok(out) = Command::new("df").args(["-k", path]).output() {
-        if let Some(line) = String::from_utf8_lossy(&out.stdout).lines().nth(1) {
-            let p: Vec<&str> = line.split_whitespace().collect();
-            if p.len() >= 4 {
-                if let (Ok(blk), Ok(avail)) = (p[1].parse::<f64>(), p[3].parse::<f64>()) {
-                    let tg = blk / (1024.0 * 1024.0);
-                    let fg = avail / (1024.0 * 1024.0);
-                    return ToolCallResult::ok(
-                        json!({
-                            "total_gb": (tg * 10.0).round() / 10.0,
-                            "free_gb": (fg * 10.0).round() / 10.0,
-                            "used_gb": ((tg - fg) * 10.0).round() / 10.0,
-                        })
-                        .to_string(),
-                    );
-                }
-            }
+    if let Ok(out) = Command::new("df").args(["-k", path]).output()
+        && let Some(line) = String::from_utf8_lossy(&out.stdout).lines().nth(1)
+    {
+        let p: Vec<&str> = line.split_whitespace().collect();
+        if p.len() >= 4
+            && let (Ok(blk), Ok(avail)) = (p[1].parse::<f64>(), p[3].parse::<f64>())
+        {
+            let tg = blk / (1024.0 * 1024.0);
+            let fg = avail / (1024.0 * 1024.0);
+            return ToolCallResult::ok(
+                json!({
+                    "total_gb": (tg * 10.0).round() / 10.0,
+                    "free_gb": (fg * 10.0).round() / 10.0,
+                    "used_gb": ((tg - fg) * 10.0).round() / 10.0,
+                })
+                .to_string(),
+            );
         }
     }
     ToolCallResult::error("df failed")
@@ -210,10 +210,10 @@ fn handle_launchd(args: &Value) -> ToolCallResult {
         .to_string();
         for e in entries.flatten() {
             let name = e.file_name().to_string_lossy().to_string();
-            if let Some(ref f) = filter {
-                if !name.to_lowercase().contains(f) {
-                    continue;
-                }
+            if let Some(ref f) = filter
+                && !name.to_lowercase().contains(f)
+            {
+                continue;
             }
             agents.push(json!({ "name": name, "loaded": loaded_list.contains(&name), "path": format!("{dir}/{name}") }));
         }

--- a/src/mcp/tools_term.rs
+++ b/src/mcp/tools_term.rs
@@ -172,7 +172,7 @@ fn handle_term_read(args: &Value) -> ToolCallResult {
     let timeout_ms = args
         .get("timeout_ms")
         .and_then(|v| v.as_u64())
-        .unwrap_or(1000) as u64;
+        .unwrap_or(1000);
 
     let sessions = get_term_sessions();
     let mut guard = sessions.lock().unwrap();

--- a/src/mcp/tools_window.rs
+++ b/src/mcp/tools_window.rs
@@ -101,10 +101,10 @@ fn handle_window_list(args: &Value) -> ToolCallResult {
             if parts.len() >= 4 {
                 let app = parts[0].to_string();
                 let title = parts[1].to_string();
-                if let Some(ref f) = filter {
-                    if !app.to_lowercase().contains(f) {
-                        continue;
-                    }
+                if let Some(ref f) = filter
+                    && !app.to_lowercase().contains(f)
+                {
+                    continue;
                 }
                 windows.push(
                     json!({"app": app, "title": title, "bounds": parts[2], "size": parts[3]}),

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -338,13 +338,12 @@ impl WorkflowPlayer {
         result: &mut ReplayResult,
     ) -> Option<crate::persistent_refs::ElementRef> {
         // Strategy 1: exact fingerprint match
-        if event.element_fingerprint != 0 {
-            if let Some(elem_ref) = ref_store
+        if event.element_fingerprint != 0
+            && let Some(elem_ref) = ref_store
                 .resolve_by_fingerprint(event.element_fingerprint)
                 .filter(|r| r.alive)
-            {
-                return Some(elem_ref.clone());
-            }
+        {
+            return Some(elem_ref.clone());
         }
 
         // Strategy 2: label-based fuzzy match

--- a/src/router.rs
+++ b/src/router.rs
@@ -99,10 +99,10 @@ impl CDPConnection {
         // Look for --remote-debugging-port=XXXX in command line
         for arg in process.cmd() {
             let arg_str = arg.to_string_lossy();
-            if let Some(port_str) = arg_str.strip_prefix("--remote-debugging-port=") {
-                if let Ok(port) = port_str.parse::<u16>() {
-                    return Some(port);
-                }
+            if let Some(port_str) = arg_str.strip_prefix("--remote-debugging-port=")
+                && let Ok(port) = port_str.parse::<u16>()
+            {
+                return Some(port);
             }
         }
 
@@ -491,10 +491,10 @@ impl TestRouter {
             }
             AppType::WebViewHybrid if is_css_selector(query) => {
                 // Use WebView bridge for hybrid apps with CSS selectors
-                if let Some(ref bridge) = self.webview {
-                    if let Some(elem) = bridge.find_web_element(query) {
-                        return Ok(elem);
-                    }
+                if let Some(ref bridge) = self.webview
+                    && let Some(elem) = bridge.find_web_element(query)
+                {
+                    return Ok(elem);
                 }
                 Err(AXError::ElementNotFound(query.to_string()))
             }
@@ -578,12 +578,12 @@ fn has_chromium_helper(pid: i32) -> bool {
     system.refresh_all();
 
     for process in system.processes().values() {
-        if let Some(parent_pid) = process.parent() {
-            if parent_pid.as_u32() == pid as u32 {
-                let name = process.name().to_string_lossy();
-                if name.contains("Chromium Helper") || name.contains("Electron Helper") {
-                    return true;
-                }
+        if let Some(parent_pid) = process.parent()
+            && parent_pid.as_u32() == pid as u32
+        {
+            let name = process.name().to_string_lossy();
+            if name.contains("Chromium Helper") || name.contains("Electron Helper") {
+                return true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- apply mechanical Clippy suggestions for collapsible conditionals
- remove an unnecessary u64 cast
- keep behavior unchanged while satisfying the canonical strict Rust lint gate

## Validation
- cargo fmt --all
- git diff --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo audit
- cargo test