### PR TITLE
Pin Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+# Pin rationale: keep axterminator reproducible on the portfolio Rust baseline
+# used by sibling production repos and tracked in MIK-3181 / GitHub #55.
+# Renewal cadence: review quarterly or whenever the portfolio Rust baseline
+# moves after a successful cross-repo build/test/clippy pass.
+# Bump history:
+# - 2026-05-12: pinned to Rust 1.95.0 as the initial axterminator baseline.
+
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Summary
- Add `rust-toolchain.toml` pinned to Rust `1.95.0`.
- Include the required rationale, renewal cadence, and bump-history comments for MIK-3181 / GitHub #55.
- Leave existing edition 2024 and `rust-version = "1.95.0"` manifests unchanged.

## KPI Impact
- Improves build reproducibility for axterminator and aligns this repo with the portfolio Rust 1.95.0 baseline.
- Rollback is a single-file revert of `rust-toolchain.toml`.

## Tracking
- Linear: MIK-3181 axterminator repo slice.
- GitHub: #55 evidence follow-up.
- Commit: 48981e8

## Validation
- `cargo +1.95.0 --version` -> `cargo 1.95.0`.
- `cargo +1.95.0 fmt --all -- --check` passed.
- `CARGO_INCREMENTAL=0 cargo +1.95.0 build --workspace --locked -j 2` passed.
- `CARGO_INCREMENTAL=0 cargo +1.95.0 test --workspace -j 2` passed.
- `CARGO_INCREMENTAL=0 cargo +1.95.0 clippy --workspace --all-targets -j 2 -- -D warnings` passed.
- `cargo audit` passed.
- `git diff --check` and `git diff --cached --check` passed.
- Changed-file secret scan returned no matches.

## DoD Notes
- AC verified for axterminator repo slice: toolchain pin exists, edition 2024 already present, rust-version 1.95.x already present, pinned build/test/clippy/fmt pass.
- Initial build attempt in `/tmp` failed due local disk exhaustion only; generated target dirs were removed and the pinned build was rerun successfully with the repo target dir.
