### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to AXTerminator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-05-25
+
+### Added
+- `axterminator-core` library crate — `AppInfo`, `WindowInfo`, `SystemContext`, `MacOsAutomation` trait, `ScreenshotResult` type (PolyForm Noncommercial license)
+- Window management tools: list, focus, move, resize, minimize, close
+- Interactive terminal sessions: multi-turn CLI access
+- Extended system MCP tools: filesystem, processes, shell exec, memory, disk, network, power, launchd
+- Power tools: file edit/search/delete, HTTP, app launch, notifications
+- Enhanced TTS engine routing with Kokoro/Piper sherpa-onnx support
+- Agent output integration (MIK-3286)
+- `MacOsAutomation` trait for cross-module automation abstractions
+
+### Changed
+- Rust edition bumped to 2024; `rust-version` pinned to 1.95.0
+- `ax_type` defaults to background mode instead of focus mode
+- Toolchain pinned to Rust 1.95.0 via `rust-toolchain.toml`
+
+### Fixed
+- ApplicationServices framework linking via `build.rs` for `axterminator-core`
+- Edition-2024 migration: extern blocks, unsafe ops, borrow patterns
+- AppleScript brace escaping in format strings
+- MCP lifecycle hardening and temp file handling
+- Clippy 1.95 lints: `unnecessary_sort_by`, `manual_check`
+
+### Internal
+- Cargo.lock refreshed; resolves `--locked` incompatibility introduced by Rust 1.95.0 resolver changes
+- CI action SHAs pinned for supply-chain integrity
+- Dependabot: serde_json, sysinfo, clap_complete, tokio, lru, toml, cc updates
+
 ## [0.9.1] - 2026-04-16
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axterminator"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axterminator"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]


### PR DESCRIPTION
## Drift findings

**Root cause**: Tag \`v0.9.2\` was created on commit \`90884cd\` whose \`Cargo.toml\` still read \`version = "0.9.1"\`. The tag was an intentional CI re-trigger (commit message: \`fix(release): refresh Cargo.lock to unblock v0.9.1 aarch64-apple-darwin build\`), designed to re-run the release workflow after \`--locked\` failed against Rust 1.95.0's updated resolver metadata.

The "Publish to crates.io" step in workflow run #24899400105 completed with \`success\`, but published **0.9.1** — the version in \`Cargo.toml\` at that commit. \`0.9.2\` was never sent to crates.io.

V: Confirmed via \`cargo search axterminator\` (returns \`0.9.1\`) and \`GET crates.io/api/v1/crates/axterminator/versions\` (lists \`0.1.0\` through \`0.9.1\`, no \`0.9.2\`).

**Stale \`v0.9.2\` tag**: leave it. It documents a real, successful CI run for the 0.9.1 republish. Deleting erases auditable history for no gain.

## Semver rationale

| Constraint | Version |
|---|---|
| Latest on crates.io | \`0.9.1\` |
| Latest git tag | \`v0.9.2\` (tag only, not on crates.io) |
| Must be strictly greater than | both of the above |
| **Selected** | **\`0.10.0\`** |

I: 46 commits since \`v0.9.2\` include multiple \`feat:\` entries (axterminator-core library extraction, window management tools, interactive terminal sessions, extended system MCP tools, enhanced TTS routing, Rust edition 2024 migration). Pre-1.0 semver: new features trigger a MINOR bump. \`0.10.0 > 0.9.2 > 0.9.1\` satisfies both constraints.

\`cargo publish --dry-run\` confirms uploadable: \`axterminator-core\` is a workspace member only, not a \`[dependencies]\` entry in the root crate, so no PolyForm-NC registry-resolution failure.

## Changes

- \`Cargo.toml\`: \`version = "0.9.1"\` to \`"0.10.0"\`
- \`Cargo.lock\`: workspace version entry updated (\`cargo update -w\`)
- \`CHANGELOG.md\`: \`[0.10.0]\` section added summarising 46 commits

## AC

- [x] AC.RELEASE.1 \`Cargo.toml\` version is \`0.10.0\`
- [x] AC.RELEASE.2 \`0.10.0\` is strictly greater than latest crates.io version (\`0.9.1\`) and latest tag (\`v0.9.2\`)
- [x] AC.RELEASE.3 \`cargo publish --dry-run\` exits 0
- [x] AC.RELEASE.4 \`cargo fmt --check\` clean
- [x] AC.RELEASE.5 \`cargo clippy --all-targets -- -D warnings -A unexpected_cfgs\` clean
- [x] AC.RELEASE.6 \`cargo test --all-features -- --skip live_\`: 1395 passed, 2 pre-existing failures
- [x] AC.RELEASE.7 No tag pushed, no \`cargo publish\` executed
- [x] AC.RELEASE.8 PR targets \`main\`; branch is \`chore/release-v0.10.0\`

## Pre-existing failures (not introduced here)

\`element::tests::test_element_exists\` and \`element::tests::test_get_string_attribute\` fail in any environment without live macOS Accessibility permissions. Both lack the \`live_\` prefix convention. They are present and failing identically on \`origin/main\` before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)