### PR TITLE
chore(release): fix x86_64 release build, cut v0.10.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual trigger validates the build matrix without burning a tag.
+  # Publish/release/homebrew jobs are guarded to run only on tag refs.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -31,6 +34,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # rust-toolchain.toml pins the active toolchain to 1.95.0, overriding the
+      # `stable` toolchain the action just installed. The `targets:` input above
+      # adds the rust-std component to `stable`, NOT to the pinned 1.95.0
+      # toolchain — so `cargo build --target x86_64-apple-darwin` fails with
+      # E0463 "can't find crate for std". Running rustup inside the checkout dir
+      # adds the target to the pinned toolchain that actually builds.
+      - name: Add target to pinned toolchain
+        run: rustup target add ${{ matrix.target }}
+
       - name: Build release binary
         run: cargo build --release --locked --features cli --target ${{ matrix.target }}
 
@@ -48,6 +60,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [build-rust]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -79,6 +92,7 @@ jobs:
   publish-crates-io:
     name: Publish to crates.io
     needs: [build-rust]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: macos-14
     environment:
       name: crates-io
@@ -97,6 +111,7 @@ jobs:
   update-homebrew:
     name: Update Homebrew tap
     needs: [release]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment:
       name: homebrew

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to AXTerminator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-05-25
+
+### Fixed
+- Release pipeline: the `x86_64-apple-darwin` build failed with E0463 (`can't find crate for std`) because `rust-toolchain.toml` pins the active toolchain to 1.95.0, overriding the `stable` toolchain whose rust-std target was added by the toolchain action. Added an explicit `rustup target add` step that runs inside the checkout directory so the target lands on the pinned toolchain. The v0.10.0 tag's release run failed before publishing, so v0.10.1 is the first 0.10.x release reaching crates.io, GitHub Releases, and the Homebrew tap.
+- Release workflow now supports `workflow_dispatch` for validating the build matrix without consuming a tag; publish/release/homebrew jobs are guarded to run only on tag refs.
+
 ## [0.10.0] - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axterminator"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axterminator"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]


### PR DESCRIPTION
## Summary
- The v0.10.0 release run ([26420420374](https://github.com/MikkoParkkola/axterminator/actions/runs/26420420374)) failed: the `x86_64-apple-darwin` leg hit `error[E0463]: can't find crate for std`. `rust-toolchain.toml` pins the active toolchain to 1.95.0, which overrides the `stable` toolchain that the dtolnay action added the x86_64 rust-std target onto. The pinned toolchain had no x86_64 std, so the cross-target build failed. Because `publish-crates-io`, `release`, and `update-homebrew` all `needs: [build-rust]`, the matrix half-failure skipped them — crates.io stayed at 0.9.1 and no GitHub Release was cut.
- Fix: explicit `rustup target add ${{ matrix.target }}` step that runs inside the checkout dir, so the target installs on the pinned 1.95.0 toolchain that actually builds.
- Adds `workflow_dispatch` so the build matrix can be validated without consuming a tag; guards publish/release/homebrew with `if: startsWith(github.ref, 'refs/tags/')` so a branch dispatch can't publish or release.
- Bumps to 0.10.1 (tags are immutable; v0.10.0 never reached crates.io, so 0.10.1 is the first 0.10.x release to ship).

## Test plan
- [ ] Normal PR CI green
- [ ] After merge: `workflow_dispatch` on main → both `build-rust` legs (aarch64 + x86_64) succeed
- [ ] Tag v0.10.1 → publish-crates-io + GitHub Release + Homebrew all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)