### PR TITLE
docs: add commercial license sponsor rail

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [MikkoParkkola]

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -18,11 +18,35 @@ Examples that require a commercial license:
 
 Commercial terms are flexible and can be structured as:
 
+- Standard GitHub Sponsors commercial-use license.
 - Attribution plus upstream collaboration.
 - Revenue share.
 - Fixed license fee.
 - Support or integration contract.
 - Strategic partnership.
 
-Commercial users should contact Mikko Parkkola before shipping or relying on
-AXTerminator in a business context.
+## Standard commercial license
+
+Companies can buy a standard commercial-use license through GitHub Sponsors:
+
+- EUR 500/month per named project.
+- Covers one company or organization using AXTerminator while sponsorship remains active.
+- Covers routine internal business use, private forks, wrappers, private integrations, and shared internal services for that organization.
+- Requires the sponsoring company to identify the licensed project, such as AXTerminator, in the sponsor note or by email.
+- Does not include support, SLA, custom development, indemnity, trademark rights, sublicensing, resale, or the right to offer AXTerminator as a hosted or managed service to third parties unless separately agreed in writing.
+
+The standard license is intended to be simple enough for normal team, department, or manager-level purchasing. It is not a blanket license for all Mikko Parkkola projects.
+
+## Custom commercial terms
+
+Custom terms are available for larger or unusual deployments, including:
+
+- Multiple projects or portfolio-wide use.
+- External-facing SaaS, hosted, managed-service, or resale use.
+- Redistribution to customers, subsidiaries, contractors, or channel partners.
+- High-scale deployments, regulated environments, procurement-specific contract terms, indemnity, support, SLA, or custom development.
+- Strategic partnerships, revenue share, attribution plus upstream collaboration, or annual invoicing.
+
+Sponsor link: https://github.com/sponsors/MikkoParkkola
+
+Annual invoicing, procurement terms, custom terms, or resale rights can be agreed by email: mikko.parkkola@iki.fi

--- a/README.md
+++ b/README.md
@@ -284,5 +284,8 @@ open-source, and free public-good projects with attribution.
 Business use requires a written commercial license. See [LICENSE.md](LICENSE.md)
 and [COMMERCIAL.md](COMMERCIAL.md).
 
+Companies can buy a standard commercial-use license via
+[GitHub Sponsors](https://github.com/sponsors/MikkoParkkola) at EUR 500/month per named project.
+
 Earlier releases published under `MIT OR Apache-2.0` remain under those earlier
 license grants for those earlier versions only.


### PR DESCRIPTION
## Summary

Adds GitHub Sponsors funding metadata and clarifies the standard commercial-license path for business use.

## Acceptance criteria

- AC-001: `.github/FUNDING.yml` points to `MikkoParkkola` so GitHub can show the Sponsor button after merge.
- AC-002: README/license docs describe the standard EUR 500/month per named project commercial-use path.
- AC-003: Annual invoicing and custom terms are clearly handled by email agreement.
- AC-004: Existing open-source license grants are preserved; Enterprise Edition/commercial boundaries are clarified where applicable.

## ROI

P1 / high leverage: makes the payment path visible at the point where companies evaluate the repo, while keeping normal noncommercial and core open-source use clear.

## Fail-fast

If GitHub does not render the Sponsor button after merge, verify the default-branch `.github/FUNDING.yml` path and GitHub Sponsors profile status before changing licensing text.

## Source

Requested by @MikkoParkkola to make Sponsor buttons appear where commercial licensing makes sense and to clarify per-project licensing terms.
