### PR TITLE
ci: gate builds + releases on known dependency vulnerabilities

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -1,0 +1,35 @@
+# osv-scanner allowlist — the pressure valve for the CI security gate.
+#
+# The gate fails the build on ANY known, fixable vulnerability in the
+# dependency tree. It runs in two places:
+#   - ci.yml `osv-scan` job          -> fast layer, fires on every PR/push
+#   - release.yml `security-gate` job -> backstop, blocks the release if a
+#     vuln slipped past CI between merge and tag
+#
+# Scope (verified by local run 2026-06-05): Rust crates — osv-scanner reads
+# Cargo.lock and checks every dependency (including ones cargo-audit/RustSec
+# might treat differently) against OSV. NOT covered: github-actions advisories
+# (our actions are SHA-pinned, which is itself the mitigation, and osv-scanner
+# does not map SHA pins to advisory versions). There is no Docker image in this
+# repo, so no OS-layer / base-image CVE surface to scan. This covers the primary
+# attack surface: the Rust dependency tree that .github/dependabot.yml's cargo
+# updater watches.
+#
+# Failing on any fixable vuln is intentional: a new build must include the
+# security fixes that are available. Dependabot PROPOSES the bump PR; this gate
+# DISPOSES — it refuses to ship until the fix is merged.
+#
+# When a vulnerability has NO upstream fix yet, or is verified unreachable, it
+# would otherwise block every release indefinitely. Add a time-boxed exception
+# here instead of weakening the gate. Each entry MUST carry a reason and an
+# ignoreUntil review date — expired entries re-trigger the gate automatically.
+#
+# Format (https://google.github.io/osv-scanner/configuration/):
+#
+#   [[IgnoredVulns]]
+#   id = "RUSTSEC-2024-1234"
+#   ignoreUntil = 2026-07-01   # review by this date; after it the gate fires again
+#   reason = "No patched release upstream yet; verified unreachable. Reviewed 2026-06-05 by <who>."
+#
+# Keep this list EMPTY unless a vuln genuinely has no fix. The right fix for a
+# fixable vuln is to bump the dependency, not to ignore it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,26 @@ jobs:
         with:
           extra_args: --only-verified
 
+  # Dependency-vulnerability gate: scans Cargo.lock against the OSV database on
+  # every PR and push. Fails the build on any known, fixable vuln so a security
+  # fix lands with the change that introduces (or fails to bump past) it — not
+  # weeks later. osv-scanner is the only dep-vuln gate in this repo; cargo's
+  # dependabot updater PROPOSES bumps, this gate DISPOSES — it refuses to ship
+  # until the fix is merged. Accepted/unfixable vulns are time-boxed in
+  # .github/osv-scanner.toml. The release.yml `security-gate` job is the backstop.
+  osv-scan:
+    name: OSV vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan Rust dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   clippy:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Release backstop for the dependency-vulnerability gate. ci.yml scans on
+  # every PR/push; this re-scans at tag time so a vuln that landed between the
+  # last green CI run and the release tag (or via a path that skipped CI) cannot
+  # ship. build-rust `needs:` this gate, and every publishing job is transitively
+  # rooted at build-rust (release, publish-crates-io -> build-rust; update-homebrew
+  # -> release) — so the GitHub release, crates.io publish, and Homebrew tap all
+  # block if a known fixable vuln is present. Exceptions are time-boxed in
+  # .github/osv-scanner.toml.
+  security-gate:
+    name: Security gate (block release on known vulns)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan Rust dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   build-rust:
     name: Build Rust ${{ matrix.target }}
+    needs: [security-gate]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds an `osv-scanner` dependency-vulnerability gate so neither a PR build nor a release can ship with a known, fixable vulnerability in the `Cargo.lock` dependency tree. Mirrors the gating pattern from MikkoParkkola/trvl #141, adapted for this Rust crate (no Docker image here, so no trivy/image-layer scan — osv-scanner covers the full dependency surface).

## Why

**V:** Audit of the current pipeline found no dependency-vulnerability gate. `ci.yml` runs `cargo check`/`test`/`fmt`/`clippy` and a trufflehog secrets scan, but nothing checks dependencies against an advisory database. `release.yml` publishes (GitHub release, crates.io, Homebrew) off `build-rust` with no security precondition. `dependabot.yml` proposes cargo bumps weekly, but nothing *enforces* that a fixable vuln blocks shipping.

This gate closes that: dependabot PROPOSES the bump PR; this gate DISPOSES — it refuses to build or release until the fix is merged.

## What changed

**I:** Three files, all actions SHA-pinned.

- `.github/osv-scanner.toml` — empty allowlist plus doctrine for time-boxed exceptions. Each exception MUST carry a `reason` and an `ignoreUntil` review date; expired entries re-trigger the gate. Kept empty unless a vuln genuinely has no upstream fix.
- `.github/workflows/ci.yml` — new blocking `osv-scan` job (`ubuntu-latest`), fires on every PR/push. Auto-detects `Cargo.lock`.
- `.github/workflows/release.yml` — new `security-gate` job; `build-rust` now `needs: [security-gate]`.

Pinned action: `google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8`
Scan args: `--config=.github/osv-scanner.toml`, `--recursive`, `./`.

## Release DAG wiring

`security-gate` is wired as the single chokepoint at the root of the publish DAG:

```
security-gate
   └─ build-rust (needs: [security-gate])
        ├─ release            (needs: [build-rust])  -> GitHub Release
        │     └─ update-homebrew (needs: [release])  -> Homebrew tap
        └─ publish-crates-io  (needs: [build-rust])  -> crates.io
```

Because every publishing job is transitively rooted at `build-rust`, a known fixable vuln blocks the entire release — GitHub release, crates.io, and the Homebrew formula bump all gate on the same scan.

## Local verification

**A:** Ran the exact action invocation locally from the worktree on 2026-06-05:

```
$ osv-scanner --config=.github/osv-scanner.toml --recursive ./
Scanned .../Cargo.lock file and found 291 packages
No issues found
EXIT=0
```

291 packages, **no known vulnerabilities, exit 0** — clean. No exceptions were added to the toml (none needed; nothing silenced).

YAML of both touched workflows validated (`yaml.safe_load`); TOML validated (`tomllib.load`).

## Scope notes

- No Docker image in this repo, so no base-image/OS-layer CVE surface — trivy is not applicable (unlike trvl).
- GitHub Actions advisories are not mapped by osv-scanner against SHA pins; the SHA pinning is itself the mitigation, and dependabot's `github-actions` updater watches for action bumps.
- `osv-scanner` complements (does not replace) the existing trufflehog secrets scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
