### PR TITLE
Add npm wrapper for npx/Claude-Desktop distribution

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,55 @@
+# axterminator (npm)
+
+npm distribution for [**axterminator**](https://github.com/MikkoParkkola/axterminator) — an MCP server for macOS desktop automation that lets AI agents see and control macOS applications through the Accessibility API.
+
+This package is a thin wrapper. On install it downloads the matching native binary from the corresponding GitHub release and verifies it against the published SHA-256 checksum before use.
+
+## Requirements
+
+- **macOS only** (arm64 or x64). axterminator drives the macOS Accessibility API; it does not run on Linux or Windows.
+- Node.js >= 16 (for the installer only; the tool itself is a native binary).
+
+## Use as an MCP server
+
+Run directly:
+
+```sh
+npx axterminator mcp serve
+```
+
+Or wire it into an MCP client:
+
+```json
+{
+  "mcpServers": {
+    "axterminator": {
+      "command": "axterminator",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+(After a global install: `npm install -g axterminator`.)
+
+## CLI
+
+The wrapper forwards all arguments to the native binary, so the full CLI works too:
+
+```sh
+npx axterminator tree --app Finder
+npx axterminator mcp serve --http 8080 --token secret
+```
+
+## How it works
+
+`postinstall` runs `bin/install.js`, which:
+
+1. Resolves the macOS target triple (`aarch64-apple-darwin` / `x86_64-apple-darwin`).
+2. Downloads the binary + `checksums-sha256.txt` from the release tagged `v<package-version>`.
+3. Verifies the SHA-256 and refuses to install on mismatch.
+4. Writes the executable into the package `bin/` directory.
+
+## License
+
+See [LICENSE.md](https://github.com/MikkoParkkola/axterminator/blob/main/LICENSE.md) (AXTerminator Community License). For full docs, see the [main repository](https://github.com/MikkoParkkola/axterminator).

--- a/npm/bin/axterminator.js
+++ b/npm/bin/axterminator.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+"use strict";
+
+// Thin launcher: exec the downloaded native binary, forwarding all arguments
+// transparently so `axterminator` via npm behaves exactly like the native CLI.
+// MCP clients invoke it as: { "command": "axterminator", "args": ["mcp", "serve"] }
+
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const binaryPath = path.join(__dirname, "axterminator");
+
+if (!fs.existsSync(binaryPath)) {
+  console.error("axterminator binary not found. Re-run the install step:");
+  console.error("  node " + path.join(__dirname, "install.js"));
+  process.exit(1);
+}
+
+const child = spawn(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+
+child.on("error", (err) => {
+  console.error(`Failed to start axterminator: ${err.message}`);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});

--- a/npm/bin/install.js
+++ b/npm/bin/install.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+"use strict";
+
+// Postinstall: download the platform-matching axterminator binary from the
+// matching GitHub release and verify it against the published SHA-256 checksum
+// before writing it to disk. axterminator drives the macOS Accessibility API,
+// so this package is macOS-only by design.
+
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+const VERSION = require("../package.json").version;
+const REPO = "MikkoParkkola/axterminator";
+
+function target() {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      `axterminator is macOS-only (it drives the macOS Accessibility API). ` +
+        `Current platform: ${process.platform}.`
+    );
+  }
+  if (process.arch === "arm64") return "aarch64-apple-darwin";
+  if (process.arch === "x64") return "x86_64-apple-darwin";
+  throw new Error(
+    `Unsupported macOS architecture: ${process.arch} (need arm64 or x64).`
+  );
+}
+
+function download(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        if (
+          res.statusCode >= 300 &&
+          res.statusCode < 400 &&
+          res.headers.location
+        ) {
+          return download(res.headers.location).then(resolve).catch(reject);
+        }
+        if (res.statusCode !== 200) {
+          return reject(new Error(`HTTP ${res.statusCode} from ${url}`));
+        }
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+        res.on("error", reject);
+      })
+      .on("error", reject);
+  });
+}
+
+function sha256(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+async function install() {
+  let triple;
+  try {
+    triple = target();
+  } catch (err) {
+    console.error(`\n${err.message}\n`);
+    process.exit(1);
+  }
+
+  const assetName = `axterminator-${triple}`;
+  const base = `https://github.com/${REPO}/releases/download/v${VERSION}`;
+  const binDir = __dirname;
+  const binaryPath = path.join(binDir, "axterminator");
+
+  if (fs.existsSync(binaryPath)) {
+    console.log(`axterminator binary already present at ${binaryPath}`);
+    return;
+  }
+
+  console.log(`Downloading axterminator v${VERSION} (${triple})...`);
+  console.log(`  ${base}/${assetName}`);
+
+  let binary, checksums;
+  try {
+    [binary, checksums] = await Promise.all([
+      download(`${base}/${assetName}`),
+      download(`${base}/checksums-sha256.txt`),
+    ]);
+  } catch (err) {
+    console.error(`\nFailed to download axterminator:\n  ${err.message}\n`);
+    console.error(
+      `Download manually from:\n  https://github.com/${REPO}/releases/tag/v${VERSION}\n`
+    );
+    process.exit(1);
+  }
+
+  // Verify the binary against the published checksum before trusting it.
+  const expectedLine = checksums
+    .toString("utf8")
+    .split("\n")
+    .find((l) => l.includes(assetName));
+  if (!expectedLine) {
+    console.error(
+      `No checksum entry for ${assetName} in checksums-sha256.txt — refusing to install.`
+    );
+    process.exit(1);
+  }
+  const expected = expectedLine.trim().split(/\s+/)[0];
+  const actual = sha256(binary);
+  if (expected !== actual) {
+    console.error(
+      `Checksum mismatch for ${assetName}:\n  expected ${expected}\n  actual   ${actual}\n` +
+        `Refusing to install a binary that does not match the published checksum.`
+    );
+    process.exit(1);
+  }
+
+  fs.writeFileSync(binaryPath, binary);
+  fs.chmodSync(binaryPath, 0o755);
+  console.log(
+    `axterminator v${VERSION} installed and verified (sha256 ${actual.slice(0, 12)}…).`
+  );
+}
+
+install();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "axterminator",
+  "version": "0.10.1",
+  "description": "MCP server for macOS desktop automation: give AI agents the ability to see and control macOS apps via the Accessibility API. Background GUI testing, sub-millisecond element access, self-healing locators. Works with Claude, Cursor, Windsurf, and any MCP client.",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MikkoParkkola/axterminator"
+  },
+  "homepage": "https://mikkoparkkola.github.io/axterminator/",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "macos",
+    "gui-automation",
+    "accessibility",
+    "accessibility-api",
+    "desktop-automation",
+    "ui-testing",
+    "claude",
+    "cursor",
+    "windsurf",
+    "ai-agents",
+    "model-context-protocol",
+    "automation",
+    "screenshot",
+    "self-healing-locators"
+  ],
+  "bin": {
+    "axterminator": "bin/axterminator.js"
+  },
+  "files": [
+    "bin/axterminator.js",
+    "bin/install.js",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "node bin/install.js"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "engines": {
+    "node": ">=16"
+  }
+}


### PR DESCRIPTION
## Why

axterminator is an MCP server with no npm channel. MCP clients (Claude Desktop, Cursor, Windsurf, etc.) default to launching servers via `npx` — so without an npm package, axterminator is invisible to its default install path. The portfolio's highest-volume MCP package (trvl-mcp, 2,636 installs/mo) reaches that audience precisely through an npm wrapper around a native binary; this brings the same path to axterminator.

`axterminator` (unscoped) is available on npm and collision-free.

## What

A thin npm wrapper under `npm/`, modeled on trvl's, with three deliberate improvements for this repo's release shape:

- **macOS-only** (`os: ["darwin"]`, arm64/x64) — axterminator drives the macOS Accessibility API; the installer errors clearly on other platforms instead of half-installing.
- **Raw-binary download** matching this repo's release assets (`axterminator-<triple>`), not goreleaser tarballs.
- **SHA-256 verification** against the published `checksums-sha256.txt` before the binary is trusted — closes the postinstall-downloads-a-binary trust surface. Refuses to install on mismatch or missing checksum.

The launcher forwards all args transparently, so `npx axterminator mcp serve` and the full CLI both work; MCP config stays `{ "command": "axterminator", "args": ["mcp", "serve"] }`.

## Verification (run on macOS arm64, v0.10.1)

```
node --check bin/install.js        -> OK
node --check bin/axterminator.js   -> OK
node bin/install.js                -> downloaded + verified (sha256 2de1d55fea7a…)
./bin/axterminator --version       -> axterminator 0.10.1
```

## Publishing (operator)

Version is pinned to `0.10.1` to match the current release tag. To publish:

```
cd npm && npm publish --access public
```

Future releases: bump `npm/package.json` version to match the new tag, then `npm publish`. (A release-workflow step can automate this in a follow-up.)

## Notes
- [x] Installer is macOS-gated and checksum-verified
- [x] Live install + run smoke-tested on macOS arm64
- [ ] CI green
- [ ] `npm publish` (operator — needs NPM_TOKEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)