### PR TITLE
Publish npm wrapper on release via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,3 +178,28 @@ jobs:
           git add Formula/axterminator.rb
           git commit -m "axterminator ${GITHUB_REF_NAME}" || echo "No changes"
           git push
+
+  publish-npm:
+    name: Publish npm wrapper
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # OIDC token for npm trusted publishing + provenance
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # OIDC trusted publishing needs npm >= 11.5.1; Node 24 bundles a recent npm.
+      - name: Set up Node 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Stamp version from tag and publish (OIDC, no token)
+        working-directory: npm
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "${VERSION}" --no-git-tag-version --allow-same-version
+          npm publish --provenance --access public


### PR DESCRIPTION
## Why

PR #94 added the npm wrapper; this makes releases actually publish it — token-free, via npm Trusted Publishing (OIDC), the same pattern trvl uses for `trvl-mcp`. No stored NPM_TOKEN to manage or rotate, and published with provenance attestation.

## What

Adds a `publish-npm` job to release.yml (mirrors the existing `release`/`publish-crates-io` guards: tag-only, `needs: [release]`). It stamps `npm/package.json` to the tag version and runs `npm publish --provenance --access public` with `id-token: write`.

## One-time setup (operator, no secret to copy)

On npmjs.com → for package `axterminator` → **Settings → Trusted Publisher → GitHub Actions**:
- Repository: `MikkoParkkola/axterminator`
- Workflow: `release.yml`
- Environment: (none)

npm supports configuring a **pending** trusted publisher for a name that doesn't exist yet, so this works for the first publish — the initial release creates `axterminator` on npm. (If npm requires the package to exist first in your account, do one manual `npm publish` with a token, then this job takes over tokenlessly.)

## Notes
- [x] YAML validated; job graph: build-rust → release → publish-npm
- [ ] CI green
- [ ] Operator: configure trusted publisher, then cut a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)