### PR TITLE
docs: cross-link related agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ axterminator is part of a suite of MCP tools:
 | [nab](https://github.com/MikkoParkkola/nab) | Web content extraction — fetch any URL with cookies + anti-bot bypass |
 | **[axterminator](https://github.com/MikkoParkkola/axterminator)** | **macOS GUI automation — 34 MCP tools via Accessibility API** |
 
+## Related projects
+
+Independent, no-API-key tools for AI agents — each useful alone:
+
+- [trvl](https://github.com/MikkoParkkola/trvl) — travel MCP server + CLI (flights, hotels, trains, cars, ferries)
+- [mcp-gateway](https://github.com/MikkoParkkola/mcp-gateway) — one endpoint that multiplexes many MCP servers
+- [nab](https://github.com/MikkoParkkola/nab) — token-lean web fetch (any URL → clean markdown) for agents
+
 ## License
 
 AXTerminator is free for personal, research, educational, noncommercial


### PR DESCRIPTION
Adds a `## Related projects` section to the README linking the sibling agent-infra tools (trvl, mcp-gateway, nab) so visitors discover them. Docs-only, no code changes.