### PR TITLE
release: v0.10.2 — deliver two months of dependency fixes that never shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to AXTerminator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-08-04
+
+### Security
+- **openssl 0.10.78 -> 0.10.80**, clearing GHSA-xp3w-r5p5-63rr (high). The advisory published 2026-05-05 and v0.10.1 shipped 2026-05-25, twenty days later, so every installed copy of 0.10.1 carries it. Exploitability is low in this context (X509 OCSP-responder parsing of non-UTF-8 URLs, and AES-KW-PAD ciphers) but the fix has been sitting on `main` undelivered for over two months.
+- **crossbeam-epoch 0.9.18 -> 0.9.20**, clearing RUSTSEC-2026-0204.
+- **openssl-sys 0.9.114 -> 0.9.116**, **tokio 1.52.3 -> 1.53.1**, **base64 0.22.1 -> 0.23.0**, **regex 1.12.3 -> 1.13.1**.
+
+### Changed
+- Thirty-six dependency versions advanced since v0.10.1, none of which had reached a released artifact. Beyond the security items above: ort 2.0.0-rc.12 -> rc.13, tungstenite 0.29.0 -> 0.30.0, syn 2.0.117 -> 3.0.2, digest 0.10.7 -> 0.11.3, sha1 0.10.6 -> 0.11.0, shlex 1.3.0 -> 2.0.1, cc 1.2.62 -> 1.4.0, clap 4.6.1 -> 4.6.4, thiserror 2.0.18 -> 2.0.19, sysinfo 0.39.2 -> 0.39.6, and the serde/tokio/toml families.
+
+### Notes
+- **No functional changes.** This release exists solely to deliver dependency fixes that accumulated on `main` and never reached users.
+- Found by a portfolio-wide security audit on 2026-08-04. The gap was invisible because **Dependabot scans only the default branch**: this repository showed 35 fixed and 0 open alerts while the binary users had installed predated every one of those fixes. A clean alert count on `main` says nothing about what has actually shipped.
+
 ## [0.10.1] - 2026-05-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axterminator"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axterminator"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]


### PR DESCRIPTION
## Why

**No functional changes.** This release exists because the fixes were merged and never released.

`v0.10.1` (2026-05-25) ships **openssl 0.10.78**, carrying **GHSA-xp3w-r5p5-63rr** (high). The advisory published **2026-05-05 — twenty days before that release**, so every installed copy has it. `main` has carried openssl 0.10.80 for weeks.

Verified at the source:

```
openssl at shipped tag v0.10.1:  0.10.78
openssl at origin/main:          0.10.80
```

## What ships

**Security**
- openssl 0.10.78 → 0.10.80 (GHSA-xp3w-r5p5-63rr)
- crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)
- openssl-sys 0.9.114 → 0.9.116, tokio 1.52.3 → 1.53.1, base64 0.22.1 → 0.23.0, regex 1.12.3 → 1.13.1

**Everything else** — 36 dependency versions advanced against the shipped tag: ort rc.12 → rc.13, tungstenite 0.29 → 0.30, syn 2.0 → 3.0, digest 0.10 → 0.11, sha1 0.10 → 0.11, shlex 1.3 → 2.0, cc 1.2 → 1.4, clap 4.6.1 → 4.6.4, thiserror 2.0.18 → 2.0.19, plus the serde / tokio / toml families.

## How this stayed invisible

**Dependabot scans only the default branch.** This repository reported **35 fixed, 0 open** alerts while the binary users had installed predated every one of those 35 fixes. A clean alert count on `main` says nothing about what has shipped.

Found in a portfolio-wide audit on 2026-08-04. The same blind spot left the Homebrew tap serving `nab` 0.10.3 — two minor versions and roughly two months behind — which was fixed separately today.

## Note on the base

Branched from `origin/main` at `927176a`, fetched immediately before branching. An earlier attempt was cut from a local clone that was **11 commits stale**; releasing from it would have shipped an older dependency set and reverted ten merged bumps.

## After merge

Tag `v0.10.2` on main. The release workflow triggers on `v*` and publishes to GitHub Releases, crates.io and the Homebrew tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)