### PR TITLE
docs: correct tool counts and document the shell/filesystem surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## What To Do
 
-You are setting up `axterminator` -- an MCP server that gives you the ability to see and control macOS applications via the Accessibility API. 27 core tools, up to 34+ with optional features. Run these steps in order:
+You are setting up `axterminator` -- an MCP server that gives you the ability to see and control macOS applications via the Accessibility API. 62 tools with default features, 84 with optional features (audio, camera, spaces, watch, context, docker, HTTP transport). Run these steps in order:
 
 ### Step 1: Install
 
@@ -76,7 +76,7 @@ axterminator find "File" --app Finder
 # Expected: UI element match
 ```
 
-Tell the user: "AXTerminator is installed with up to 34 MCP tools. I can see your screen, click buttons, type text, take screenshots, read UI trees, run AppleScript, audit accessibility, and control apps in the background while you work. Just tell me what to do."
+Tell the user: "AXTerminator is installed with 62 MCP tools. I can see your screen, click buttons, type text, take screenshots, read UI trees, run AppleScript, audit accessibility, and control apps in the background while you work. The same server also lets me run shell commands, read and write files, and open terminal sessions on this Mac. Just tell me what to do."
 
 ---
 
@@ -116,7 +116,7 @@ You now have MCP tools to control any macOS application. Tools are grouped by ca
 | Tool | What it does |
 |------|-------------|
 | `ax_assert` | Assert element state (exists, enabled, value) |
-| `ax_find_visual` | Visual element detection (requires VLM) |
+| `ax_find_visual` | Returns a screenshot plus a sampling request so your own model can locate the element |
 | `ax_visual_diff` | Visual regression testing (compare screenshots) |
 | `ax_a11y_audit` | WCAG accessibility compliance audit |
 
@@ -130,6 +130,31 @@ You now have MCP tools to control any macOS application. Tools are grouped by ca
 | `ax_session_info` | Server session state |
 | `ax_analyze` | Detect UI patterns, infer app state, suggest actions |
 | `ax_query` | Natural language UI questions |
+
+### Shell, Files and Terminal
+
+These are part of the default build and are not limited to the connected app.
+
+| Tool | What it does |
+|------|-------------|
+| `ax_exec` | Run a shell command via `/bin/sh -c` as the user running the server |
+| `ax_fs_read` / `ax_fs_write` / `ax_fs_edit` / `ax_fs_delete` | Read, write, find-and-replace, delete a path (`~/` expanded, no sandbox) |
+| `ax_fs_list` / `ax_fs_search` | List a directory, search file contents |
+| `ax_term_start` / `ax_term_send` / `ax_term_read` / `ax_term_close` / `ax_term_list` | Interactive PTY sessions that persist across calls |
+| `ax_http_get` | HTTP GET to any URL |
+| `ax_app_launch` / `ax_notify` | Launch or quit an app, post a notification |
+| `ax_process_list`, `ax_system_memory`, `ax_system_disk`, `ax_system_network`, `ax_system_power`, `ax_system_launchd`, `ax_system_context` | Machine state |
+
+Ask the user before touching files or running commands they did not request.
+`AXTERMINATOR_SECURITY_MODE=safe` blocks `ax_exec` and `ax_run_script`;
+`sandboxed` allows read-only tools only.
+
+### Windows
+
+| Tool | What it does |
+|------|-------------|
+| `ax_window_list` | List windows with positions |
+| `ax_window_focus` / `ax_window_move` / `ax_window_resize` / `ax_window_minimize` / `ax_window_tile` | Focus, move, resize, minimize, tile a window |
 
 ### Workflows
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,21 @@
 # AXTerminator
 
-MCP server + CLI that gives AI agents the ability to see and control macOS applications via the Accessibility API. 27 core tools, up to 34+ with feature flags. Rust, macOS-only.
+MCP server + CLI that gives AI agents the ability to see and control macOS applications via the Accessibility API. 62 tools with default features, 84 with all feature flags. Rust, macOS-only.
 
 > `AGENTS.md` in this repo is the public install-facing guide for end-user agents (see `trvl` pattern). This file (`CLAUDE.md`) is for contributing agents. They are intentionally diverged; do not symlink.
 
 ## Product Vision
 
-AXTerminator lets an AI agent observe and operate macOS applications **in the background**, with sub-millisecond element access (~379 us), self-healing locators, and structured-output MCP tools. It is the eyes-and-hands of a macOS agent: click, type, query UI state, capture screens, record audio, see camera input, manage virtual desktops. AX-first with vision-fallback means most interactions use the accessibility tree (fast, reliable, semantic), falling back to screenshot+vision only when AX is not available (e.g. Electron web views without proper ARIA).
+AXTerminator lets an AI agent observe and operate macOS applications **in the background**, with sub-millisecond element access (~379 us) and structured-output MCP tools. It is the eyes-and-hands of a macOS agent: click, type, query UI state, capture screens, record audio, see camera input, manage virtual desktops. AX-first with vision-fallback means most interactions use the accessibility tree (fast, reliable, semantic), falling back to screenshot+vision only when AX is not available (e.g. Electron web views without proper ARIA).
 
 The boundary is macOS-only. iOS/iPadOS support is tracked but will be screenshot+vision only — the `idevice`/RPPairing surface does not expose AX trees for third-party apps, and UIAutomation would require an on-device test runner which breaks the "mac-only agent, no on-device prereqs" contract.
 
 ## Current Status
 
-- **v0.9.1** · Rust stable · macOS 12+ · last MIT + Apache-2.0 dual-license release
-- **27 core tools** (default features) plus up to 34+ with `audio`, `camera`, `spaces`, `watch`, `context`, `docker`, `parakeet`, `http-transport` feature flags
+- **v0.10.2** · Rust stable · macOS 12+ · PolyForm Noncommercial 1.0.0 (v0.9.1 was the last MIT + Apache-2.0 release)
+- **62 tools** on default features, **84** with `audio`, `camera`, `spaces`, `watch`, `context`, `docker`, `http-transport` (measured via `tools/list`). Default set includes shell (`ax_exec`), filesystem (`ax_fs_*`), PTY terminals (`ax_term_*`), window management and HTTP GET, none of them scoped to the connected app
 - **~1000 tests** on default features; full suite with `--all-features`; CI runs `test --all-features` on macOS
-- **Performance**: 379 us per element access, 7-strategy self-healing locators, ObjC FFI for CoreFoundation / CoreGraphics / AVFoundation
+- **Performance**: 379 us per element access, ObjC FFI for CoreFoundation / CoreGraphics / AVFoundation
 - **iOS**: tracked in #43, demoted to screenshot+vision tier (~350 ms USB, ~700 ms WiFi via CoreDeviceProxy)
 - **tvOS**: unverified; RSD surface narrower than `idevice`'s tvOS target suggests
 
@@ -54,7 +54,7 @@ The boundary is macOS-only. iOS/iPadOS support is tracked but will be screenshot
 - **Before editing a tool schema**: check MCP 2025-11-25 annotation matrix in MIK-2986; every tool needs `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` plus `title`.
 - **When adding a feature-gated module**: mirror `src/audio/` pattern — feature flag in `Cargo.toml`, `cfg`-gated module, `.m` file compilation in `build.rs`, integration test behind `live_` prefix.
 - **Cross-app interaction**: use `src/app.rs` for app connection and `src/element.rs` for element abstraction — do not bypass to raw `accessibility.rs` FFI.
-- **Self-healing locators**: the 7-strategy system in `src/healing.rs` / `healing_match.rs` is the primary stability mechanism; do not bypass it with hard-coded selectors.
+- **Self-healing locators**: `find_with_healing` in `src/healing.rs` has no caller — `ax_find` goes through `AXApp::find_element` (criteria parse, cache, breadth-first search). Wire it up or leave it alone, but do not describe it in docs as the live find path.
 - **Build + test parity with CI**: `cargo fmt --check && cargo clippy --all-features -- -D warnings -A unexpected_cfgs && cargo test --all-features -- --skip live_`
 
 ## Where to Look
@@ -94,14 +94,17 @@ CI skips tests that use the `live_` prefix (`cargo test --all-features -- --skip
   - `tools_innovation.rs` -- analyze, record, audit, workflow tools
   - `tools_capture.rs` -- screenshot, session capture
   - `tools_audio.rs` / `tools_camera.rs` / `tools_spaces.rs` -- feature-gated
+  - `tools_system.rs` / `tools_system_ext.rs` / `tools_power.rs` -- shell exec, filesystem, HTTP, machine state
+  - `tools_term.rs` -- PTY terminal sessions
+  - `tools_window.rs` -- window move/resize/tile/focus
   - `protocol.rs` -- MCP message types, capabilities
   - `annotations.rs` -- tool annotation constants (readOnly, destructive, etc.)
-  - `elicitation.rs` -- confirmation prompts for destructive actions
+  - `elicitation.rs` -- elicitation request builders; nothing calls them, so no `elicitation/create` is ever sent
   - `transport.rs` -- stdio + optional HTTP transport
 - `src/app.rs` -- macOS app connection, element search
 - `src/accessibility.rs` -- AXUIElement FFI wrappers
 - `src/element.rs` -- UI element abstraction
-- `src/healing.rs` / `healing_match.rs` -- 7-strategy self-healing locators
+- `src/healing.rs` / `healing_match.rs` -- 7-strategy self-healing locator library API (no caller in the MCP/CLI path)
 - `src/intent.rs` / `intent_matching.rs` -- scene graph, UI pattern detection
 - `src/copilot.rs` -- AI copilot state tracking
 - `src/spaces.rs` -- virtual desktop management (feature-gated)
@@ -111,7 +114,7 @@ CI skips tests that use the `live_` prefix (`cargo test --all-features -- --skip
 
 ## Feature Flags
 
-`cli` (default), `audio`, `camera`, `spaces`, `http-transport`, `watch`, `context`, `docker`, `parakeet`
+`cli` (default), `audio`, `enhanced-tts`, `camera`, `spaces`, `http-transport`, `watch`, `context`, `docker`, `parakeet`
 
 ## Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 
 ---
 
-Up to 34+ MCP tools (27 core + optional audio, camera, spaces). Background interaction via the macOS Accessibility API. 379us per element access. Audio capture, camera input, virtual desktop isolation. Your AI agent connects and your Mac becomes an extension of it.
+62 MCP tools with default features, 84 with the optional audio, camera, spaces, watch, context, docker and HTTP-transport flags. Background interaction via the macOS Accessibility API. 379us per element access. Audio capture, camera input, virtual desktop isolation. Your AI agent connects and your Mac becomes an extension of it.
+
+Not only the UI: the default build also exposes a shell (`ax_exec`), file read/write/delete, PTY terminal sessions and outbound HTTP GET. See [Beyond the UI](#beyond-the-ui).
 
 **Platform scope.** AX-first-with-vision-fallback is **macOS-only**. iOS/iPadOS support is tracked in [#43](https://github.com/MikkoParkkola/axterminator/issues/43) as a future capability and, when shipped, will be **screenshot + vision only** — the `idevice`/RPPairing surface does not expose AX trees for third-party apps, and UIAutomation would require an on-device test runner (breaks the "mac-only agent, no on-device prereqs" contract). Reported screenshot latency via CoreDeviceProxy: **~350ms USB, ~700ms WiFi** (credit [@m13v](https://github.com/MikkoParkkola/axterminator/issues/43#issuecomment-4274488358)). tvOS is **unverified** — the RSD surface is narrower than `idevice`'s tvOS target suggests; please open an issue with device evidence if you've tested. See [#42](https://github.com/MikkoParkkola/axterminator/issues/42) for the AX-first-vs-vision-first positioning rationale.
 
@@ -87,7 +89,7 @@ args = ["mcp", "serve"]
 
 </details>
 
-Done. Your agent has 27 core tools (up to 34+ with all feature flags) to control any macOS app.
+Done. Your agent has 62 tools (84 with all feature flags) to control any macOS app.
 
 ## MCP Tools
 
@@ -96,7 +98,9 @@ Done. Your agent has 27 core tools (up to 34+ with all feature flags) to control
 | **GUI** | `ax_connect`, `ax_find`, `ax_click`, `ax_click_at`, `ax_type`, `ax_set_value`, `ax_get_value`, `ax_scroll`, `ax_drag`, `ax_key_press` | Connect to apps, find elements, interact |
 | **Observe** | `ax_is_accessible`, `ax_screenshot`, `ax_get_tree`, `ax_get_attributes`, `ax_list_windows`, `ax_list_apps`, `ax_wait_idle` | Check permissions, see UI state, screenshots |
 | **Verify** | `ax_assert`, `ax_find_visual`, `ax_visual_diff`, `ax_a11y_audit` | Assert element state, AI vision fallback, visual regression, WCAG audit |
-| **System** | `ax_clipboard`, `ax_run_script`, `ax_undo`, `ax_session_info`, `ax_analyze` | Clipboard, AppleScript/JXA, undo actions, session state, UI analysis |
+| **System** | `ax_clipboard`, `ax_run_script`, `ax_undo`, `ax_session_info`, `ax_analyze`, `ax_system_context`, `ax_system_memory`, `ax_system_disk`, `ax_system_network`, `ax_system_power`, `ax_system_launchd`, `ax_process_list` | Clipboard, AppleScript/JXA, undo actions, session state, UI analysis, machine state |
+| **Windows** | `ax_window_list`, `ax_window_focus`, `ax_window_move`, `ax_window_resize`, `ax_window_minimize`, `ax_window_tile` | Move, resize, tile, focus windows |
+| **Shell & files** | `ax_exec`, `ax_fs_read`, `ax_fs_write`, `ax_fs_edit`, `ax_fs_search`, `ax_fs_delete`, `ax_fs_list`, `ax_term_start`, `ax_term_send`, `ax_term_read`, `ax_term_close`, `ax_term_list`, `ax_http_get`, `ax_app_launch`, `ax_notify` | Run shell commands, read/write/delete files, drive interactive terminal sessions, fetch a URL, launch or quit apps |
 | **Audio** | `ax_listen`, `ax_speak`, `ax_audio_voices`, `ax_audio_devices` | Capture mic/system audio, text-to-speech, inspect installed macOS voices; optional Kokoro/Piper TTS via `enhanced-tts` |
 | **Camera** | `ax_camera_capture`, `ax_gesture_detect`, `ax_gesture_listen` | Camera frames, gesture recognition |
 | **Spaces** | `ax_list_spaces`, `ax_create_space`, `ax_move_to_space`, `ax_switch_space`, `ax_destroy_space` | Virtual desktop isolation |
@@ -113,9 +117,28 @@ Agents can browse app state without tool calls:
 | `axterminator://app/{name}/state` | Focused element, window title |
 | `axterminator://system/displays` | Monitor layout |
 
+### Beyond the UI
+
+The default build is not limited to the app you connect to. `ax_exec` runs any
+command through `/bin/sh -c` as the user who started the server. `ax_fs_read`,
+`ax_fs_write`, `ax_fs_edit` and `ax_fs_delete` use the path you give them, with
+`~/` expanded and no project sandbox. `ax_term_start` opens a PTY session that
+persists across calls. `ax_http_get` fetches any URL. All of these are on by
+default and are not covered by the accessibility permission.
+
+To narrow that: `AXTERMINATOR_SECURITY_MODE=safe` blocks `ax_exec` and
+`ax_run_script`, `sandboxed` allows read-only tools only, and
+`~/.config/axterminator/security.toml` restricts which apps can be connected.
+See [Configuration](docs/api/config.md).
+
 ### Security
 
-Destructive actions require confirmation via elicitation. HTTP transport requires bearer token auth. The AI has hands, not root.
+`ax_click` refuses to click an element whose label reads destructive (delete,
+remove, quit, and similar) unless the call sets `confirm=true`. That flag is a
+tool argument the calling agent sets itself, not a prompt to you, and no other
+tool has such a gate. Every mutating call is appended to
+`~/.local/share/axterminator/audit.jsonl`. HTTP transport binds `127.0.0.1` and
+requires a bearer token unless started with `--localhost-only`.
 
 ## CLI
 
@@ -156,7 +179,7 @@ AXTerminator uses an undocumented behavior of Apple's Accessibility API: `AXUIEl
 
 379us per element access (Criterion, M1 MacBook Pro). Appium needs 500ms for the same thing.
 
-7-strategy self-healing locators survive UI changes: data_testid, aria_label, identifier, title, xpath, position, visual_vlm.
+`ax_find` parses the query into search criteria and runs a cached breadth-first search of the accessibility tree, with fuzzy scene-graph matching as a fallback. The 7-strategy self-healing chain (data_testid, aria_label, identifier, title, xpath, position, visual_vlm) is a library API, `axterminator::find_with_healing`, and is not on the `ax_find` path.
 
 ## AX-first vs Vision-first
 
@@ -196,7 +219,7 @@ Any macOS app that exposes the Accessibility API: all native AppKit/SwiftUI apps
 
 **Does it work with agents that are already doing computer use?**
 
-Yes. Add `axterminator mcp install --client codex` (or `--client claude-code`, etc.) and the agent gains 34 semantic tools it can call instead of pixel-clicking. It doesn't replace the agent's vision; it gives the agent a faster, cheaper path for the 90%+ of actions that don't need vision.
+Yes. Add `axterminator mcp install --client codex` (or `--client claude-code`, etc.) and the agent gains 62 tools it can call instead of pixel-clicking. It doesn't replace the agent's vision; it gives the agent a faster, cheaper path for the 90%+ of actions that don't need vision.
 
 **Who is it for beyond developers?**
 
@@ -248,6 +271,9 @@ cargo build --release --features "cli,audio,enhanced-tts,camera,spaces"
 | `enhanced-tts` | Optional Kokoro/Piper TTS engine routing and `axterminator models tts` downloads |
 | `camera` | Camera capture, gesture detection |
 | `spaces` | Virtual desktop management |
+| `watch` | Continuous background monitoring (implies audio + camera) |
+| `context` | Geolocation via CoreLocation |
+| `docker` | Browser containers as isolated test targets (requires Docker) |
 | `http-transport` | HTTP MCP transport with auth |
 
 ## Community
@@ -275,7 +301,7 @@ axterminator is part of a suite of MCP tools:
 | [mcp-gateway](https://github.com/MikkoParkkola/mcp-gateway) | Universal MCP gateway — compact 12-15 tool surface replaces 100+ registrations |
 | [trvl](https://github.com/MikkoParkkola/trvl) | AI travel agent — 36 MCP tools for flights, hotels, ground transport |
 | [nab](https://github.com/MikkoParkkola/nab) | Web content extraction — fetch any URL with cookies + anti-bot bypass |
-| **[axterminator](https://github.com/MikkoParkkola/axterminator)** | **macOS GUI automation — 34 MCP tools via Accessibility API** |
+| **[axterminator](https://github.com/MikkoParkkola/axterminator)** | **macOS GUI automation — 62 MCP tools via Accessibility API** |
 
 ## License
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-AXTerminator is a macOS GUI testing framework that provides background testing (interacting with applications without stealing window focus), sub-millisecond element access via direct Accessibility API calls, and self-healing locators with 7 fallback strategies.
+AXTerminator is a macOS GUI testing framework that provides background testing (interacting with applications without stealing window focus), sub-millisecond element access via direct Accessibility API calls, and a 7-strategy self-healing locator API in the library (`find_with_healing`, not used by the MCP tools or CLI).
 
 ### Key Differentiators
 

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -1,23 +1,31 @@
 # MCP Tools Reference
 
-AXTerminator v0.6.1 exposes up to 30 MCP tools (19 core + optional audio, camera, spaces), 5 resources, 4 guided prompts, and 9 elicitation scenarios.
+AXTerminator v0.10.2 exposes 62 MCP tools with default features and 84 with
+`audio,camera,spaces,watch,context,docker,http-transport` enabled, plus 6
+resources, 4 resource templates and 10 guided prompts. Counts measured with
+`tools/list`, `resources/list` and `prompts/list` against the built binary.
 
-## Core Tools (19)
+Many of these tools reach outside the app you connected to: a shell, the
+filesystem, interactive terminal sessions and outbound HTTP are all on by
+default. See [Beyond the UI](#beyond-the-ui-shell-filesystem-terminal) before
+you point an agent at this server.
+
+## UI Tools (19)
 
 ### GUI Interaction
 
 | Tool | Description | Annotations |
 |------|-------------|-------------|
-| `ax_connect` | Connect to a running application by name, bundle ID, or PID | readOnly |
+| `ax_connect` | Connect to a running application by name, bundle ID, or PID | idempotent |
 | `ax_find` | Find a UI element by query string | readOnly |
-| `ax_click` | Click an element (background by default) | destructive |
-| `ax_click_at` | Click at screen coordinates | destructive |
+| `ax_click` | Click an element (background by default); refuses destructive-looking labels without `confirm=true` | action |
+| `ax_click_at` | Click at screen coordinates | action |
 | `ax_type` | Type text into an element (requires focus) | destructive |
 | `ax_set_value` | Set element value directly via AXValue attribute | destructive |
 | `ax_get_value` | Read element value | readOnly |
-| `ax_scroll` | Scroll within an element | destructive |
-| `ax_drag` | Drag from one element/position to another | destructive |
-| `ax_key_press` | Press a keyboard key or combination | destructive |
+| `ax_scroll` | Scroll within an element | action |
+| `ax_drag` | Drag from one element/position to another | action |
+| `ax_key_press` | Press a keyboard key or combination | action |
 
 ### Observation
 
@@ -45,14 +53,101 @@ handler checks the AX tree before returning a screenshot sampling request. AX AP
 facts then win over screen vision for the same target. Unset or `legacy` mode
 preserves historical visual lookup behavior.
 
-## Audio Tools (4) -- `audio` feature
+## Session, Analysis and Workflow (16)
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_analyze` | Detect UI patterns, infer app state, suggest next actions | readOnly |
+| `ax_query` | Natural-language question about the current UI | readOnly |
+| `ax_app_profile` | Electron/web app metadata for a connected app | readOnly |
+| `ax_a11y_audit` | Accessibility compliance audit | readOnly |
+| `ax_visual_diff` | Compare a screenshot against a stored baseline | readOnly |
+| `ax_record` | Record a UI interaction for test generation | action |
+| `ax_test_run` | Black-box test execution | action |
+| `ax_track_workflow` | Cross-app workflow tracking | action |
+| `ax_workflow_create` / `ax_workflow_step` / `ax_workflow_status` | Multi-step workflow planning and progress | action / action / readOnly |
+| `ax_session_info` | Server session state | readOnly |
+| `ax_undo` | Undo the last actions in an app (Cmd+Z) | destructive |
+| `ax_clipboard` | Read or write the system clipboard | destructive |
+| `ax_run_script` | Execute AppleScript or JXA | destructive |
+| `ax_system_context` | System context snapshot (battery, volume, dark mode, and similar) | readOnly |
+
+## Beyond the UI: shell, filesystem, terminal
+
+These tools are part of the default build. They are not scoped to the app you
+connected to, and they are not scoped to a project directory: paths are used as
+given (with `~/` expanded), and commands run as the user who started the server.
+Run the server in `safe` or `sandboxed` mode, or with an app policy file, if
+that is more reach than you want. See
+[Configuration](config.md#security-modes).
+
+### System and Shell (7)
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_exec` | Run a shell command via `/bin/sh -c`; returns stdout, stderr, exit code | destructive |
+| `ax_process_list` | List running processes | readOnly |
+| `ax_system_memory` | Memory statistics | readOnly |
+| `ax_system_disk` | Disk usage | readOnly |
+| `ax_system_network` | Network interfaces | readOnly |
+| `ax_system_power` | Power and thermal status | readOnly |
+| `ax_system_launchd` | List launchd agents | readOnly |
+
+### Filesystem (6)
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_fs_read` | Read file contents | readOnly |
+| `ax_fs_write` | Write content to a file | destructive |
+| `ax_fs_list` | List directory contents | readOnly |
+| `ax_fs_edit` | Find and replace in a file (backup on by default) | destructive |
+| `ax_fs_search` | Search file contents | readOnly |
+| `ax_fs_delete` | Delete a file or directory | destructive |
+
+### Terminal Sessions (5)
+
+PTY-backed sessions that persist across tool calls, so an agent can drive an
+interactive program (a REPL, `ssh`, an installer) over several turns.
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_term_start` | Start a long-lived interactive command, returns a session ID | destructive |
+| `ax_term_send` | Send input to a session | destructive |
+| `ax_term_read` | Read output from a session | readOnly |
+| `ax_term_close` | Close a session | destructive |
+| `ax_term_list` | List active sessions | readOnly |
+
+### Network, Apps and Notifications (3)
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_http_get` | HTTP GET to any URL; returns status, headers, body | readOnly |
+| `ax_app_launch` | Launch or quit an application | destructive |
+| `ax_notify` | Post a macOS notification via `osascript` | destructive |
+
+## Window Management (6)
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_window_list` | List windows with positions | readOnly |
+| `ax_window_focus` | Focus a window by title or app | destructive |
+| `ax_window_move` | Move a window | destructive |
+| `ax_window_resize` | Resize a window | destructive |
+| `ax_window_minimize` | Minimize a window | destructive |
+| `ax_window_tile` | Tile a window to a screen region | destructive |
+
+## Audio Tools (8) -- `audio` feature
 
 | Tool | Description | Annotations |
 |------|-------------|-------------|
 | `ax_listen` | Capture audio and transcribe via SFSpeechRecognizer (48kHz native) | readOnly |
-| `ax_speak` | Text-to-speech via system, Kokoro, or Piper engines | openWorld |
+| `ax_speak` | Text-to-speech via system, Kokoro, or Piper engines | action |
 | `ax_audio_voices` | List installed macOS speech voices | readOnly |
 | `ax_audio_devices` | List available audio input/output devices | readOnly |
+| `ax_start_capture` | Start background screen and audio capture | action |
+| `ax_stop_capture` | Stop a running capture session | action |
+| `ax_get_transcription` | Read recent transcription from the capture buffer | readOnly |
+| `ax_capture_status` | Query capture session status | readOnly |
 
 ## Camera Tools (3) -- `camera` feature
 
@@ -67,22 +162,53 @@ preserves historical visual lookup behavior.
 | Tool | Description | Annotations |
 |------|-------------|-------------|
 | `ax_list_spaces` | List all virtual desktops | readOnly |
-| `ax_create_space` | Create a new virtual desktop | destructive |
-| `ax_move_to_space` | Move a window to a specific space | destructive |
-| `ax_switch_space` | Switch active space | destructive |
-| `ax_destroy_space` | Destroy a virtual desktop | destructive |
+| `ax_create_space` | Create a new virtual desktop | action |
+| `ax_move_to_space` | Move a window to a specific space | action |
+| `ax_switch_space` | Switch active space | action |
+| `ax_destroy_space` | Destroy a virtual desktop | action |
 
-## Resources (5)
+## Watch Tools (3) -- `watch` feature
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_watch_start` | Start continuous audio/camera monitoring | action |
+| `ax_watch_stop` | Stop all active watchers | action |
+| `ax_watch_status` | Check watch monitoring status | readOnly |
+
+## Browser Container Tools (2) -- `docker` feature
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_browser_launch` | Launch an isolated browser container | action |
+| `ax_browser_stop` | Stop and remove a browser container | destructive |
+
+## Location (1) -- `context` feature
+
+| Tool | Description | Annotations |
+|------|-------------|-------------|
+| `ax_location` | Current GPS location via CoreLocation | readOnly |
+
+## Resources (6)
 
 | URI | Description |
 |-----|-------------|
-| `axterminator://apps` | Running applications |
-| `axterminator://app/{name}/tree` | Live element hierarchy |
-| `axterminator://app/{name}/screenshot` | Current screenshot (base64 PNG) |
-| `axterminator://app/{name}/state` | Focused element, window title |
+| `axterminator://apps` | Running applications with PIDs, bundle IDs, accessibility info |
+| `axterminator://system/status` | Accessibility permissions, connected app count, server version |
 | `axterminator://system/displays` | Monitor layout and Retina scaling |
+| `axterminator://clipboard` | Current clipboard text; subscribable for change notifications |
+| `axterminator://workflows` | Cross-app patterns observed via `ax_track_workflow` |
+| `axterminator://profiles` | Built-in Electron app profiles (VS Code, Slack, Chrome, Terminal, Finder) |
 
-## Guided Prompts (4)
+### Resource Templates (4)
+
+| URI template | Description |
+|--------------|-------------|
+| `axterminator://app/{name}/tree` | Live element hierarchy (depth 3 by default) |
+| `axterminator://app/{name}/screenshot` | Current screenshot (base64 PNG) |
+| `axterminator://app/{name}/state` | Focused element, window title, visible text |
+| `axterminator://app/{name}/query/{question}` | Natural-language scene query |
+
+## Guided Prompts (10)
 
 | Prompt | Description |
 |--------|-------------|
@@ -90,16 +216,27 @@ preserves historical visual lookup behavior.
 | `navigate-to` | Navigate to a specific screen or element |
 | `extract-data` | Extract structured data from a UI |
 | `accessibility-audit` | Audit an app's accessibility compliance |
+| `troubleshooting` | Guidance when something fails: element not found, click not working, screenshot failing |
+| `app-guide` | Per-app query syntax, interaction methods and known quirks (Calculator, TextEdit, Safari, Chrome, Finder, Notes) |
+| `automate-workflow` | Plan and track a multi-step workflow with `ax_workflow_create` / `step` / `status` |
+| `debug-ui` | Debug why an element cannot be found: walk the tree, check attributes, suggest queries |
+| `cross-app-copy` | Copy data between two applications |
+| `analyze-app` | Detect patterns, infer state, suggest actions, audit accessibility |
 
-## Elicitation
+## Confirmation of Destructive Actions
 
-Destructive and ambiguous operations trigger elicitation dialogs for user confirmation. There are 9 elicitation scenarios covering:
+One tool asks for confirmation: `ax_click` refuses to click an element whose
+title or description contains a destructive word (delete, remove, erase, quit,
+close, format, reset, clear, wipe, destroy, terminate, uninstall) and returns an
+error telling the caller to re-send with `confirm=true`. The confirmation is a
+tool argument, so the calling agent can satisfy it on its own; it is not a
+prompt to the human.
 
-- Destructive clicks (e.g., "Delete", "Remove")
-- Text input into sensitive fields
-- Drag operations
-- Space management (create/destroy)
-- Application termination
+No other tool has a confirmation gate. `ax_exec`, `ax_fs_write`,
+`ax_fs_delete`, `ax_term_send` and the rest run on the first call. The server
+declares the MCP `elicitation` capability and the request builders exist in
+`src/mcp/elicitation.rs`, but nothing in the server calls them, so no
+`elicitation/create` request is ever sent.
 
 ## Tool Annotations
 
@@ -112,8 +249,13 @@ All tools carry MCP tool annotations:
 | `idempotentHint` | Calling multiple times has same effect |
 | `openWorldHint` | Tool interacts with external systems |
 
+"action" in the tables above means the tool sets none of these hints: it changes
+state and is not idempotent, but is not marked destructive.
+
 ## Security
 
-- **Bearer token auth** required for HTTP transport (`--token` flag)
-- **Localhost-only** binding for HTTP transport by default
-- Structured MCP logging with progress notifications
+- Stdio transport has no authentication: whatever launches the server can call every tool.
+- HTTP transport (`http-transport` feature) binds `127.0.0.1` by default and uses a bearer token. Without `--token` a random one is generated and printed to stderr; `--localhost-only` skips authentication and is refused on a non-loopback bind.
+- `AXTERMINATOR_SECURITY_MODE=safe` blocks the scripting tools, `sandboxed` allows read-only tools only. Both are described in [Configuration](config.md#security-modes).
+- Every mutating tool call is appended to `~/.local/share/axterminator/audit.jsonl`.
+- Structured MCP logging with progress notifications.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -107,7 +107,6 @@ Appium:       Client → HTTP → Node.js → XCTest → AXUIElement → Element
 - Speed matters (1000+ element operations)
 - Testing native macOS apps
 - You are driving the Mac from an AI agent over MCP
-- You need self-healing locators
 
 ### Use XCUITest when:
 - You're already in the Apple ecosystem

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -52,7 +52,9 @@ args = ["mcp", "serve"]
 
 Open **System Settings > Privacy & Security > Accessibility** and add your terminal app.
 
-Your agent now has 19 core tools to control any macOS app.
+Your agent now has 62 tools to control any macOS app. That includes a shell
+(`ax_exec`), file read/write/delete and PTY terminal sessions, all on by
+default; see [MCP Tools](../api/mcp-tools.md#beyond-the-ui-shell-filesystem-terminal).
 
 ## CLI
 

--- a/docs/guide/finding-elements.md
+++ b/docs/guide/finding-elements.md
@@ -1,6 +1,6 @@
 # Finding Elements
 
-AXTerminator provides multiple ways to locate UI elements, with automatic fallback through self-healing locators.
+AXTerminator provides multiple ways to locate UI elements. `ax_find` and `axterminator find` search the accessibility tree with a result cache; `ax_find` additionally falls back to fuzzy scene-graph matching when that finds nothing. The separate 7-strategy healing chain is a library API described in [Self-Healing](self-healing.md).
 
 ## Basic Finding
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,9 @@
 
 </div>
 
-Up to 34+ MCP tools (27 core + optional audio, camera, spaces). Background interaction via the macOS Accessibility API. 379us per element access. Audio capture with native 48kHz speech recognition, camera input with gesture detection (88.8% thumbs_up verified), virtual desktop isolation. Your AI agent connects and your Mac becomes an extension of it.
+62 MCP tools with default features, 84 with the optional audio, camera, spaces, watch, context, docker and HTTP-transport flags. Background interaction via the macOS Accessibility API. 379us per element access. Audio capture with native 48kHz speech recognition, camera input with gesture detection (88.8% thumbs_up verified), virtual desktop isolation. Your AI agent connects and your Mac becomes an extension of it.
 
-**Current version: 0.8.0** --- Rust binary with MCP server, CLI, and optional audio/camera/spaces features.
+**Current version: 0.10.2** --- Rust binary with MCP server, CLI, and optional audio/camera/spaces features.
 
 ## Deploy
 
@@ -64,7 +64,7 @@ args = ["mcp", "serve"]
 
 Replace `/path/to/axterminator` with the actual binary path.
 
-Done. Your agent has 27 core tools (up to 34+ with all feature flags) to control any macOS app.
+Done. Your agent has 62 tools (84 with all feature flags) to control any macOS app.
 
 ## MCP Tools
 
@@ -73,7 +73,9 @@ Done. Your agent has 27 core tools (up to 34+ with all feature flags) to control
 | **GUI** | `ax_connect`, `ax_find`, `ax_click`, `ax_click_at`, `ax_type`, `ax_set_value`, `ax_get_value`, `ax_scroll`, `ax_drag`, `ax_key_press` | Connect to apps, find elements, interact |
 | **Observe** | `ax_is_accessible`, `ax_screenshot`, `ax_get_tree`, `ax_get_attributes`, `ax_list_windows`, `ax_list_apps`, `ax_wait_idle` | Check permissions, see UI state, screenshots |
 | **Verify** | `ax_assert`, `ax_find_visual`, `ax_visual_diff`, `ax_a11y_audit` | Assert element state, AI vision fallback, visual regression, WCAG audit |
-| **System** | `ax_clipboard`, `ax_run_script`, `ax_undo`, `ax_session_info`, `ax_analyze` | Clipboard, AppleScript/JXA, undo actions, session state, UI analysis |
+| **System** | `ax_clipboard`, `ax_run_script`, `ax_undo`, `ax_session_info`, `ax_analyze`, `ax_system_context`, `ax_system_memory`, `ax_system_disk`, `ax_system_network`, `ax_system_power`, `ax_system_launchd`, `ax_process_list` | Clipboard, AppleScript/JXA, undo actions, session state, UI analysis, machine state |
+| **Windows** | `ax_window_list`, `ax_window_focus`, `ax_window_move`, `ax_window_resize`, `ax_window_minimize`, `ax_window_tile` | Move, resize, tile, focus windows |
+| **Shell & files** | `ax_exec`, `ax_fs_read`, `ax_fs_write`, `ax_fs_edit`, `ax_fs_search`, `ax_fs_delete`, `ax_fs_list`, `ax_term_start`, `ax_term_send`, `ax_term_read`, `ax_term_close`, `ax_term_list`, `ax_http_get`, `ax_app_launch`, `ax_notify` | Run shell commands, read/write/delete files, drive interactive terminal sessions, fetch a URL, launch or quit apps |
 | **Audio** | `ax_listen`, `ax_speak`, `ax_audio_voices`, `ax_audio_devices` | Capture mic/system audio (48kHz native), text-to-speech; optional Kokoro/Piper via `enhanced-tts` |
 | **Camera** | `ax_camera_capture`, `ax_gesture_detect`, `ax_gesture_listen` | Camera frames, gesture recognition |
 | **Spaces** | `ax_list_spaces`, `ax_create_space`, `ax_move_to_space`, `ax_switch_space`, `ax_destroy_space` | Virtual desktop isolation |
@@ -90,9 +92,25 @@ Agents can browse app state without tool calls:
 | `axterminator://app/{name}/state` | Focused element, window title |
 | `axterminator://system/displays` | Monitor layout |
 
+### Beyond the UI
+
+The default build is not limited to the app you connect to. `ax_exec` runs any
+command through `/bin/sh -c` as the user who started the server. `ax_fs_read`,
+`ax_fs_write`, `ax_fs_edit` and `ax_fs_delete` use the path you give them, with
+`~/` expanded and no project sandbox. `ax_term_start` opens a PTY session that
+persists across calls. `ax_http_get` fetches any URL. All of these are on by
+default and are not covered by the accessibility permission.
+
 ### Security
 
-Destructive actions require confirmation via elicitation. HTTP transport requires bearer token auth. The AI has hands, not root.
+`ax_click` refuses to click an element whose label reads destructive (delete,
+remove, quit, and similar) unless the call sets `confirm=true`. That flag is a
+tool argument the calling agent sets itself, not a prompt to you, and no other
+tool has such a gate. Every mutating call is appended to
+`~/.local/share/axterminator/audit.jsonl`. `AXTERMINATOR_SECURITY_MODE=safe`
+blocks `ax_exec` and `ax_run_script`; `sandboxed` allows read-only tools only.
+HTTP transport binds `127.0.0.1` and requires a bearer token unless started with
+`--localhost-only`. See [Configuration](api/config.md).
 
 ## Feature Flags
 
@@ -110,6 +128,8 @@ cargo build --release --features "cli,audio,enhanced-tts,camera,spaces"
 | `camera` | Camera capture, gesture detection (88.8% thumbs_up verified) |
 | `watch` | Continuous background monitoring (implies audio + camera) |
 | `spaces` | Virtual desktop management (CGSSpace private API) |
+| `context` | Geolocation via CoreLocation |
+| `docker` | Browser containers as isolated test targets (requires Docker) |
 | `http-transport` | Streamable HTTP MCP transport with bearer token auth |
 
 ## CLI
@@ -129,7 +149,7 @@ AXTerminator uses an undocumented behavior of Apple's Accessibility API: `AXUIEl
 
 379us per element access (Criterion, M1 MacBook Pro). Appium needs 500ms for the same thing.
 
-7-strategy self-healing locators survive UI changes: data_testid, aria_label, identifier, title, xpath, position, visual_vlm.
+`ax_find` parses the query into search criteria and runs a cached breadth-first search of the accessibility tree, with fuzzy scene-graph matching as a fallback. The 7-strategy self-healing chain is a library API, `axterminator::find_with_healing`; see [Self-Healing](guide/self-healing.md).
 
 ## Performance
 

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 
 ## What This Is
 
-AXTerminator is an MCP server that gives you (the AI agent) the ability to see and control macOS applications via the Accessibility API. 19-34+ tools depending on features.
+AXTerminator is an MCP server that gives you (the AI agent) the ability to see and control macOS applications via the Accessibility API. 62 tools with default features, 84 with all optional features. It also exposes a shell, filesystem access and terminal sessions on this Mac -- see "Beyond the UI" below.
 
 ## Requirements
 
@@ -22,7 +22,7 @@ which axterminator 2>/dev/null || echo "NOT INSTALLED"
 
 # If installed, check version
 axterminator check 2>/dev/null
-# Look at the "Version:" line — current release is 0.8.0
+# Look at the "Version:" line — current release is 0.10.2
 ```
 
 If already installed at an older version, follow the Upgrade section below.
@@ -196,7 +196,7 @@ axterminator mcp serve --http 8741 --localhost-only
 axterminator mcp serve --http 8741 --token YOUR_SECRET_TOKEN
 ```
 
-## Available Tools (34+)
+## Available Tools (62 default, 84 with all features)
 
 After connecting, call `tools/list` to get the full schema. Core tools:
 
@@ -217,7 +217,7 @@ After connecting, call `tools/list` to get the full schema. Core tools:
 - `ax_drag` — drag between coordinates
 - `ax_key_press` — send keyboard shortcuts
 - `ax_assert` — assert element state
-- `ax_find_visual` — visual element detection (requires VLM)
+- `ax_find_visual` — returns a screenshot plus a sampling request so your own model can locate the element
 - `ax_visual_diff` — visual regression testing (compare screenshots against baseline)
 - `ax_a11y_audit` — WCAG accessibility compliance audit
 - `ax_clipboard` — read/write system clipboard
@@ -232,7 +232,26 @@ After connecting, call `tools/list` to get the full schema. Core tools:
 - `ax_test_run` — black-box test execution
 - `ax_app_profile` — Electron app metadata
 
-Optional feature tools: `ax_listen`, `ax_speak`, `ax_audio_devices` (audio), `ax_camera_capture`, `ax_gesture_detect` (camera), `ax_list_spaces`, `ax_create_space` (spaces).
+- `ax_window_list` / `ax_window_focus` / `ax_window_move` / `ax_window_resize` / `ax_window_minimize` / `ax_window_tile` — window management
+- `ax_system_context`, `ax_system_memory`, `ax_system_disk`, `ax_system_network`, `ax_system_power`, `ax_system_launchd`, `ax_process_list` — machine state
+
+Optional feature tools: `ax_listen`, `ax_speak`, `ax_audio_devices` (audio), `ax_camera_capture`, `ax_gesture_detect` (camera), `ax_list_spaces`, `ax_create_space` (spaces), `ax_watch_start` (watch), `ax_browser_launch` (docker), `ax_location` (context).
+
+## Beyond the UI — shell, filesystem, terminal
+
+These ship in the default build, are not limited to the connected app, and have
+no confirmation gate. Ask the user before using them for anything they did not
+request.
+
+- `ax_exec` — run a shell command via `/bin/sh -c` as the user running the server
+- `ax_fs_read` / `ax_fs_write` / `ax_fs_edit` / `ax_fs_delete` / `ax_fs_list` / `ax_fs_search` — file access by path (`~/` expanded, no sandbox)
+- `ax_term_start` / `ax_term_send` / `ax_term_read` / `ax_term_close` / `ax_term_list` — interactive PTY sessions that persist across calls
+- `ax_http_get` — HTTP GET to any URL
+- `ax_app_launch` / `ax_notify` — launch or quit an app, post a notification
+
+`AXTERMINATOR_SECURITY_MODE=safe` blocks `ax_exec` and `ax_run_script`;
+`sandboxed` allows read-only tools only. Every mutating call is appended to
+`~/.local/share/axterminator/audit.jsonl`.
 
 ## Query Syntax
 
@@ -266,22 +285,22 @@ ax_find query="description:equals"
 ## Feature Flags (build-time)
 
 ```bash
-# Core only (default — 27 tools)
+# Core only (default — 62 tools)
 cargo build --release --features cli
 
-# With audio capture + TTS (30 tools)
+# With audio capture + TTS
 cargo build --release --features cli,audio
 
-# With camera + gesture detection (30 tools)
+# With camera + gesture detection
 cargo build --release --features cli,camera
 
-# With virtual desktop isolation (32 tools)
+# With virtual desktop isolation
 cargo build --release --features cli,spaces
 
-# Everything (34+ tools)
-cargo build --release --features cli,audio,camera,watch,spaces,http-transport
+# Everything (84 tools)
+cargo build --release --features cli,audio,camera,watch,spaces,context,docker,http-transport
 ```
 
 ## Version
 
-0.8.0
+0.10.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,11 +34,6 @@ theme:
 
 plugins:
   - search
-  - mkdocstrings:
-      handlers:
-        python:
-          options:
-            show_source: true
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -190,7 +190,7 @@ fn tool_ax_find() -> Tool {
             - By role: \"role:AXButton\"\n\
             - Combined: \"role:AXButton title:Save\"\n\
             - XPath-like: \"//AXButton[@AXTitle='OK']\"\n\
-            Uses 7-strategy self-healing locators.",
+            Searches the accessibility tree with a result cache, then falls back to fuzzy scene-graph matching.",
         input_schema: json!({
             "type": "object",
             "properties": {

--- a/src/mcp/tools_system.rs
+++ b/src/mcp/tools_system.rs
@@ -43,7 +43,7 @@ pub(crate) fn system_tools() -> Vec<Tool> {
         Tool {
             name: "ax_exec",
             title: "Execute a shell command",
-            description: "Execute a shell command via /bin/sh -c. Returns stdout, stderr, and exit code. 30s timeout.",
+            description: "Execute a shell command via /bin/sh -c. Returns stdout, stderr, and exit code. Runs to completion with no timeout.",
             input_schema: json!({"type":"object","properties":{"command":{"type":"string"},"cwd":{"type":"string"}},"required":["command"]}),
             output_schema: json!({"type":"object","properties":{"exit_code":{"type":"integer"},"stdout":{"type":"string"},"stderr":{"type":"string"}}}),
             annotations: annotations::DESTRUCTIVE,


### PR DESCRIPTION
Second drift pass on axterminator docs, after #154. Every claim below was re-checked at source; the ones that turned out to be right were left alone.

## Counts and version

Measured against the binary built from this branch:

| | doc said | `tools/list` etc. say |
|---|---|---|
| tools, default features | 19 core / 27 core / "up to 34+" | **62** |
| tools, all optional flags | 30 / 34+ | **84** |
| resources | 5 | **6** (+4 templates) |
| prompts | 4 | **10** |
| current version | v0.6.1 (`docs/api/mcp-tools.md:3`), 0.8.0 (`docs/index.md:16`, `llms.txt:287`) | 0.10.2 (`Cargo.toml:3`) |

Reproduce: `cargo build --features cli` then pipe `initialize` + `notifications/initialized` + `tools/list` into `axterminator mcp serve`.

## The part a reader could be surprised by

`CHANGELOG.md:28-34` (0.10.0) added shell exec, filesystem, terminal sessions and window management. No user-facing page mentioned them. They ship in the **default** build and are not scoped to the connected app or to a project directory:

- `ax_exec` runs `/bin/sh -c` as the user who started the server, `src/mcp/tools_system.rs:151-174`
- `ax_fs_read|write|edit|delete|list|search` use the path as given with `~/` expanded, `src/mcp/tools_system.rs:54-61`, `src/mcp/tools_power.rs:73-80`
- `ax_term_start|send|read|close|list` are PTY sessions that persist across calls, `src/mcp/tools_term.rs:1-5`
- `ax_http_get` fetches any URL, `src/mcp/tools_power.rs:35-41`

These now have their own section in `docs/api/mcp-tools.md`, plus a pointer from README, docs/index.md, quickstart, AGENTS.md and llms.txt, with the narrowing options (`AXTERMINATOR_SECURITY_MODE`, `security.toml`) named beside them.

## Claims that were wrong

- **"Destructive actions require confirmation via elicitation"** (`README.md:118`, `docs/index.md:95`). The elicitation builders in `src/mcp/elicitation.rs:193-545` have no caller in `src/` or `tests/`, so no `elicitation/create` is ever sent. The only gate is `ax_click` refusing a destructive-looking label unless the call sets `confirm=true` (`src/mcp/tools_handlers.rs:166-180`) - a tool argument the agent sets itself. "The AI has hands, not root" was sitting next to `ax_exec`.
- **"7-strategy self-healing locators"** as the live find path (`README.md:182`, `docs/index.md:150`, `docs/DESIGN.md:7`, `docs/guide/finding-elements.md:3`, `CLAUDE.md`). `find_with_healing` (`src/healing.rs:143`) has no caller. `ax_find` goes through `AXApp::find_element` - criteria parse, cache, breadth-first search (`src/app.rs:157-196`) - with a fuzzy scene-graph fallback (`src/mcp/tools_handlers.rs:109-110`). Same finding #154 recorded for `docs/guide/self-healing.md`, applied to the pages that still carried it.
- **Annotation column** in `docs/api/mcp-tools.md`: `ax_click`, `ax_click_at`, `ax_scroll`, `ax_drag`, `ax_key_press`, `ax_speak` and the four mutating space tools use `annotations::ACTION`, which sets no hints at all (`src/mcp/annotations.rs:46-51`). The table called them destructive. `ax_connect` is `CONNECT` (idempotent), not readOnly.
- Two tool descriptions shipped to agents were wrong and are fixed in code: `ax_find` claimed "Uses 7-strategy self-healing locators" (`src/mcp/tools.rs:193`), `ax_exec` claimed a "30s timeout" that `Command::output()` does not implement (`src/mcp/tools_system.rs:46`).
- `mkdocs.yml` still loaded the mkdocstrings Python handler. No page uses `:::` and the Python bindings went in v0.7.0.

## Not changed, on purpose

- `docs/design/MCP_SERVER_DESIGN.md` and `docs/architecture/decisions/` - dated design records, `pip install` and 0.6.1 references there are history.
- `docs/DESIGN.md` header `**Version**: 0.9.1 | **Last Updated**: 2026-04-26` - bumping it would assert a review of the whole document that did not happen.
- README and docs/index.md resource tables list 5 of the 6 resources. Incomplete, not false; `docs/api/mcp-tools.md` now carries the complete list.
- `CLAUDE.md:24` "v0.9.1 unblocked for aarch64-apple-darwin (#50)" - roadmap prose, not a code claim.

## Checks

`cargo fmt --check`, `cargo clippy --features cli --all-targets -- -D warnings -A unexpected_cfgs`, `cargo test --features cli --lib` (1038 passed, 0 failed).

Not merging and not arming auto-merge; a verifier reads this first.